### PR TITLE
feat(provider): add AnythingLLM as an optional docs provider

### DIFF
--- a/phone-app/src/main/java/com/example/rokidphone/ai/provider/AnythingLLMProvider.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ai/provider/AnythingLLMProvider.kt
@@ -1,0 +1,195 @@
+package com.example.rokidphone.ai.provider
+
+import com.example.rokidphone.service.ai.NetworkClientFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.util.Locale
+
+/**
+ * AnythingLLM provider adapter implementing Provider<ProviderSetting.AnythingLLM>.
+ * Relays text queries to a configured AnythingLLM workspace and surfaces
+ * source previews from the workspace's document index when present.
+ */
+class AnythingLLMProvider : Provider<ProviderSetting.AnythingLLM> {
+
+    override val providerId: String = "anythingllm"
+    override val displayName: String = "AnythingLLM"
+
+    private val client = NetworkClientFactory.createClient()
+    private val jsonMediaType = "application/json".toMediaType()
+
+    override suspend fun listModels(setting: ProviderSetting.AnythingLLM): List<Model> = emptyList()
+
+    override suspend fun validateSetting(setting: ProviderSetting.AnythingLLM): ValidationResult {
+        if (!setting.isValid()) {
+            return ValidationResult.Invalid(
+                reason = "Server URL, API key, and workspace slug are all required",
+                field = when {
+                    setting.serverUrl.isBlank() -> "serverUrl"
+                    setting.apiKey.isBlank() -> "apiKey"
+                    else -> "workspaceSlug"
+                }
+            )
+        }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val request = Request.Builder()
+                    .url("${setting.serverUrl.trimEnd('/')}/api/v1/auth")
+                    .get()
+                    .addHeader("Authorization", "Bearer ${setting.apiKey}")
+                    .build()
+
+                client.newCall(request).execute().use { response ->
+                    when {
+                        response.isSuccessful -> ValidationResult.Valid
+                        response.code == 401 -> ValidationResult.Invalid(
+                            reason = "Invalid API key: authentication failed",
+                            field = "apiKey"
+                        )
+                        else -> ValidationResult.Invalid("Connection failed: HTTP ${response.code}")
+                    }
+                }
+            } catch (e: Exception) {
+                ValidationResult.Invalid("Connection failed: ${e.message}")
+            }
+        }
+    }
+
+    override suspend fun generateText(
+        setting: ProviderSetting.AnythingLLM,
+        messages: List<ChatMessage>,
+        options: GenerationOptions
+    ): GenerationResult {
+        if (!setting.isValid()) {
+            return GenerationResult.Error(
+                message = "AnythingLLM not configured: server URL, API key, and workspace slug are required",
+                code = "invalid_setting"
+            )
+        }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val userMessage = messages.lastOrNull { it.role == MessageRole.USER }?.content.orEmpty()
+                val requestBody = JSONObject()
+                    .put("message", userMessage)
+                    .put("mode", "chat")
+                    .toString()
+
+                val request = Request.Builder()
+                    .url("${setting.serverUrl.trimEnd('/')}/api/v1/workspace/${setting.workspaceSlug}/chat")
+                    .post(requestBody.toRequestBody(jsonMediaType))
+                    .addHeader("Authorization", "Bearer ${setting.apiKey}")
+                    .addHeader("Content-Type", "application/json")
+                    .build()
+
+                client.newCall(request).execute().use { response ->
+                    val responseBody = response.body?.string()
+                    if (response.isSuccessful && responseBody != null) {
+                        val json = JSONObject(responseBody)
+                        val text = json.optNullableString("textResponse")
+                            .ifBlank { json.optNullableString("response") }
+                        GenerationResult.Success(
+                            text = appendSources(text, json),
+                            finishReason = FinishReason.STOP
+                        )
+                    } else {
+                        GenerationResult.Error(
+                            message = "Request failed: HTTP ${response.code}",
+                            code = response.code.toString(),
+                            retryable = response.code >= 500
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                GenerationResult.Error(
+                    message = "Connection error: ${e.message}",
+                    code = "connection_error",
+                    retryable = true
+                )
+            }
+        }
+    }
+
+    override fun streamText(
+        setting: ProviderSetting.AnythingLLM,
+        messages: List<ChatMessage>,
+        options: GenerationOptions
+    ): Flow<MessageChunk> = flow {
+        when (val result = generateText(setting, messages, options)) {
+            is GenerationResult.Success -> emit(
+                MessageChunk(
+                    text = result.text,
+                    isComplete = true,
+                    finishReason = result.finishReason
+                )
+            )
+            is GenerationResult.Error -> emit(
+                MessageChunk(
+                    text = "",
+                    isComplete = true,
+                    finishReason = FinishReason.ERROR,
+                    error = result.message
+                )
+            )
+        }
+    }
+
+    override suspend fun analyzeImage(
+        setting: ProviderSetting.AnythingLLM,
+        imageData: ByteArray,
+        prompt: String,
+        options: GenerationOptions
+    ): GenerationResult = GenerationResult.Error(
+        message = "AnythingLLM does not support image analysis",
+        code = "unsupported"
+    )
+
+    override suspend fun transcribe(
+        setting: ProviderSetting.AnythingLLM,
+        audioData: ByteArray,
+        options: TranscriptionOptions
+    ): TranscriptionResult = TranscriptionResult.Error(
+        message = "AnythingLLM does not support speech recognition",
+        code = "unsupported"
+    )
+
+    /**
+     * The current provider result model in this branch has no citation field.
+     * Keep source previews attached to the returned text without introducing a new type.
+     */
+    private fun appendSources(text: String, json: JSONObject): String {
+        val sources = json.optJSONArray("sources") ?: return text
+        if (sources.length() == 0) return text
+
+        val builder = StringBuilder(text).append("\n\n**Sources:**")
+        for (i in 0 until sources.length()) {
+            val source = sources.optJSONObject(i) ?: continue
+            val title = source.optNullableString("title").ifBlank { "Unknown" }
+            val chunkSource = source.optNullableString("chunkSource")
+            val url = source.optNullableString("url")
+            val score = if (source.has("score") && !source.isNull("score")) source.optDouble("score") else Double.NaN
+
+            builder.append("\n- ").append(title)
+            when {
+                url.isNotBlank() -> builder.append(" - ").append(url)
+                chunkSource.isNotBlank() -> builder.append(" (").append(chunkSource).append(")")
+            }
+            if (!score.isNaN()) {
+                builder.append(" [score: ").append(String.format(Locale.US, "%.2f", score)).append("]")
+            }
+        }
+
+        return builder.toString()
+    }
+
+    private fun JSONObject.optNullableString(name: String): String {
+        return if (has(name) && !isNull(name)) optString(name) else ""
+    }
+}

--- a/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderManager.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderManager.kt
@@ -143,6 +143,7 @@ class ProviderManager private constructor(
             AiProvider.PERPLEXITY -> settingsRepository.updatePerplexityApiKey(apiKey)
             AiProvider.MOONSHOT -> settingsRepository.updateMoonshotApiKey(apiKey)
             AiProvider.MISTRAL -> settingsRepository.updateMistralApiKey(apiKey)
+            AiProvider.ANYTHINGLLM -> settingsRepository.updateAnythingLlmApiKey(apiKey)
             AiProvider.GEMINI_LIVE -> settingsRepository.updateGeminiApiKey(apiKey)  // Shares Gemini API key
             AiProvider.CUSTOM -> settingsRepository.updateCustomApiKey(apiKey)
         }
@@ -226,6 +227,11 @@ class ProviderManager private constructor(
             AiProvider.MISTRAL -> ProviderSetting.Mistral(
                 apiKey = settings.mistralApiKey,
                 modelId = settings.aiModelId
+            )
+            AiProvider.ANYTHINGLLM -> ProviderSetting.AnythingLLM(
+                serverUrl = settings.anythingllmServerUrl,
+                apiKey = settings.anythingllmApiKey,
+                workspaceSlug = settings.anythingllmWorkspaceSlug
             )
             AiProvider.CUSTOM -> ProviderSetting.Custom(
                 apiKey = settings.customApiKey,

--- a/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderSetting.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderSetting.kt
@@ -263,6 +263,28 @@ sealed class ProviderSetting {
     }
     
     /**
+     * AnythingLLM Provider Settings
+     * Document-grounded provider that relays text queries to a configured workspace
+     * and exposes source/citation previews when available.
+     */
+    @Serializable
+    data class AnythingLLM(
+        override val id: String = "anythingllm",
+        override val displayName: String = "AnythingLLM",
+        override val enabled: Boolean = true,
+        val serverUrl: String = "",
+        val apiKey: String = "",
+        val workspaceSlug: String = ""
+    ) : ProviderSetting() {
+        @Transient
+        override val providerApiKey: String = apiKey
+        @Transient
+        override val providerBaseUrl: String = serverUrl
+        override fun isValid(): Boolean =
+            serverUrl.isNotBlank() && apiKey.isNotBlank() && workspaceSlug.isNotBlank()
+    }
+
+    /**
      * Custom OpenAI-compatible Provider Settings
      * Supports Ollama, LM Studio, vLLM, and other local deployments
      */
@@ -300,6 +322,7 @@ sealed class ProviderSetting {
             Perplexity(),
             Moonshot(),
             Mistral(),
+            AnythingLLM(),
             Custom()
         )
         
@@ -319,6 +342,7 @@ sealed class ProviderSetting {
             "perplexity" -> Perplexity()
             "moonshot" -> Moonshot()
             "mistral" -> Mistral()
+            "anythingllm" -> AnythingLLM()
             "custom" -> Custom()
             else -> null
         }

--- a/phone-app/src/main/java/com/example/rokidphone/data/ApiSettings.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/data/ApiSettings.kt
@@ -133,6 +133,15 @@ enum class AiProvider(
         supportsSpeech = true,
         supportsVision = true
     ),
+    ANYTHINGLLM(
+        displayNameResId = R.string.provider_anythingllm,
+        description = "Document-grounded retrieval via AnythingLLM workspace",
+        website = "https://anythingllm.com",
+        defaultBaseUrl = "http://localhost:3001",
+        isOpenAiCompatible = false,
+        supportsSpeech = false,
+        supportsVision = false
+    ),
     CUSTOM(
         displayNameResId = R.string.provider_custom,
         description = "OpenAI-compatible API (Ollama, LM Studio, etc.)",
@@ -581,6 +590,17 @@ object AvailableModels {
         )
     )
     
+    val anythingllmModels = listOf(
+        ModelOption(
+            id = "workspace",
+            displayName = "Workspace Model",
+            provider = AiProvider.ANYTHINGLLM,
+            supportsAudio = false,
+            supportsVision = false,
+            description = "Model determined by the AnythingLLM workspace configuration"
+        )
+    )
+
     val customModels = listOf(
         ModelOption(
             id = "custom",
@@ -999,17 +1019,18 @@ object AvailableModels {
             AiProvider.MOONSHOT -> moonshotModels
             AiProvider.MISTRAL -> mistralModels
             AiProvider.GEMINI_LIVE -> geminiLiveModels
+            AiProvider.ANYTHINGLLM -> anythingllmModels
             AiProvider.CUSTOM -> customModels
         }
     }
-    
+
     fun findModel(modelId: String): ModelOption? {
         return allModels.find { it.id == modelId }
     }
-    
+
     val allModels: List<ModelOption>
-        get() = geminiModels + openaiModels + anthropicModels + deepseekModels + groqModels + 
-                xaiModels + alibabaModels + zhipuModels + baiduModels + perplexityModels + moonshotModels + mistralModels + geminiLiveModels + customModels
+        get() = geminiModels + openaiModels + anthropicModels + deepseekModels + groqModels +
+                xaiModels + alibabaModels + zhipuModels + baiduModels + perplexityModels + moonshotModels + mistralModels + geminiLiveModels + anythingllmModels + customModels
 }
 
 /**
@@ -1044,7 +1065,12 @@ data class ApiSettings(
     val moonshotApiKey: String = "",
     val mistralApiKey: String = "",
     val customApiKey: String = "",
-    
+
+    // AnythingLLM settings
+    val anythingllmServerUrl: String = "",
+    val anythingllmApiKey: String = "",
+    val anythingllmWorkspaceSlug: String = "",
+
     // Custom base URLs (for providers that support it)
     val customBaseUrl: String = "http://localhost:11434/v1/",
     val customModelName: String = "llama4",
@@ -1173,10 +1199,11 @@ data class ApiSettings(
             AiProvider.MOONSHOT -> moonshotApiKey
             AiProvider.MISTRAL -> mistralApiKey
             AiProvider.GEMINI_LIVE -> geminiApiKey  // Shares Gemini API key
+            AiProvider.ANYTHINGLLM -> anythingllmApiKey
             AiProvider.CUSTOM -> customApiKey
         }
     }
-    
+
     /**
      * Get API Key for specified provider
      */
@@ -1195,6 +1222,7 @@ data class ApiSettings(
             AiProvider.MOONSHOT -> moonshotApiKey
             AiProvider.MISTRAL -> mistralApiKey
             AiProvider.GEMINI_LIVE -> geminiApiKey  // Shares Gemini API key
+            AiProvider.ANYTHINGLLM -> anythingllmApiKey
             AiProvider.CUSTOM -> customApiKey
         }
     }
@@ -1205,6 +1233,7 @@ data class ApiSettings(
     fun getCurrentBaseUrl(): String {
         return when (aiProvider) {
             AiProvider.CUSTOM -> customBaseUrl.ifBlank { AiProvider.CUSTOM.defaultBaseUrl }
+            AiProvider.ANYTHINGLLM -> anythingllmServerUrl.ifBlank { AiProvider.ANYTHINGLLM.defaultBaseUrl }
             else -> aiProvider.defaultBaseUrl
         }
     }
@@ -1226,6 +1255,8 @@ data class ApiSettings(
         return when (aiProvider) {
             AiProvider.CUSTOM -> customBaseUrl.isNotBlank() && isValidUrl(customBaseUrl)
             AiProvider.BAIDU -> baiduApiKey.isNotBlank() && baiduSecretKey.isNotBlank()
+            AiProvider.ANYTHINGLLM ->
+                anythingllmServerUrl.isNotBlank() && anythingllmApiKey.isNotBlank() && anythingllmWorkspaceSlug.isNotBlank()
             else -> getCurrentApiKey().isNotBlank()
         }
     }
@@ -1238,6 +1269,8 @@ data class ApiSettings(
             AiProvider.CUSTOM -> customBaseUrl.isNotBlank() && isValidUrl(customBaseUrl)
             AiProvider.BAIDU -> baiduApiKey.isNotBlank() && baiduSecretKey.isNotBlank()
             AiProvider.GEMINI_LIVE -> geminiApiKey.isNotBlank()  // Shares Gemini API key
+            AiProvider.ANYTHINGLLM ->
+                anythingllmServerUrl.isNotBlank() && anythingllmApiKey.isNotBlank() && anythingllmWorkspaceSlug.isNotBlank()
             else -> getApiKeyForProvider(provider).isNotBlank()
         }
     }
@@ -1286,6 +1319,7 @@ data class ApiSettings(
                perplexityApiKey.isNotBlank() ||
                moonshotApiKey.isNotBlank() ||
                mistralApiKey.isNotBlank() ||
+               (anythingllmApiKey.isNotBlank() && anythingllmServerUrl.isNotBlank()) ||
                (customApiKey.isNotBlank() || customBaseUrl.isNotBlank())
     }
     
@@ -1324,10 +1358,14 @@ sealed class SettingsValidationResult {
  */
 fun ApiSettings.validateForChat(): SettingsValidationResult {
     return when {
-        aiProvider == AiProvider.CUSTOM && !isValidUrl(customBaseUrl) -> 
+        aiProvider == AiProvider.CUSTOM && !isValidUrl(customBaseUrl) ->
             SettingsValidationResult.InvalidConfiguration("Invalid custom provider URL")
         aiProvider == AiProvider.BAIDU && (baiduApiKey.isBlank() || baiduSecretKey.isBlank()) ->
             SettingsValidationResult.MissingApiKey(AiProvider.BAIDU)
+        aiProvider == AiProvider.ANYTHINGLLM && !isValid() ->
+            SettingsValidationResult.InvalidConfiguration(
+                "Please configure server URL, API key, and workspace slug for AnythingLLM"
+            )
         getCurrentApiKey().isBlank() ->
             SettingsValidationResult.MissingApiKey(aiProvider)
         else -> SettingsValidationResult.Valid

--- a/phone-app/src/main/java/com/example/rokidphone/data/SettingsRepository.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/data/SettingsRepository.kt
@@ -42,7 +42,12 @@ class SettingsRepository(private val context: Context) {
         private const val KEY_PERPLEXITY_API_KEY = "perplexity_api_key"
         private const val KEY_MOONSHOT_API_KEY = "moonshot_api_key"
         private const val KEY_CUSTOM_API_KEY = "custom_api_key"
-        
+
+        // Keys for AnythingLLM provider settings (stored encrypted)
+        private const val KEY_ANYTHINGLLM_SERVER_URL = "anythingllm_server_url"
+        private const val KEY_ANYTHINGLLM_API_KEY = "anythingllm_api_key"
+        private const val KEY_ANYTHINGLLM_WORKSPACE_SLUG = "anythingllm_workspace_slug"
+
         // Keys for custom provider settings
         private const val KEY_CUSTOM_BASE_URL = "custom_base_url"
         private const val KEY_CUSTOM_MODEL_NAME = "custom_model_name"
@@ -140,7 +145,10 @@ class SettingsRepository(private val context: Context) {
             perplexityApiKey = prefs.getString(KEY_PERPLEXITY_API_KEY, "") ?: "",
             moonshotApiKey = prefs.getString(KEY_MOONSHOT_API_KEY, "") ?: "",
             customApiKey = prefs.getString(KEY_CUSTOM_API_KEY, "") ?: "",
-            customBaseUrl = prefs.getString(KEY_CUSTOM_BASE_URL, "http://localhost:11434/v1/") 
+            anythingllmServerUrl = prefs.getString(KEY_ANYTHINGLLM_SERVER_URL, "") ?: "",
+            anythingllmApiKey = prefs.getString(KEY_ANYTHINGLLM_API_KEY, "") ?: "",
+            anythingllmWorkspaceSlug = prefs.getString(KEY_ANYTHINGLLM_WORKSPACE_SLUG, "") ?: "",
+            customBaseUrl = prefs.getString(KEY_CUSTOM_BASE_URL, "http://localhost:11434/v1/")
                 ?: "http://localhost:11434/v1/",
             customModelName = prefs.getString(KEY_CUSTOM_MODEL_NAME, "llama4") ?: "llama4",
             sttProvider = SttProvider.fromName(
@@ -223,6 +231,9 @@ class SettingsRepository(private val context: Context) {
             putString(KEY_PERPLEXITY_API_KEY, settings.perplexityApiKey)
             putString(KEY_MOONSHOT_API_KEY, settings.moonshotApiKey)
             putString(KEY_CUSTOM_API_KEY, settings.customApiKey)
+            putString(KEY_ANYTHINGLLM_SERVER_URL, settings.anythingllmServerUrl)
+            putString(KEY_ANYTHINGLLM_API_KEY, settings.anythingllmApiKey)
+            putString(KEY_ANYTHINGLLM_WORKSPACE_SLUG, settings.anythingllmWorkspaceSlug)
             putString(KEY_CUSTOM_BASE_URL, settings.customBaseUrl)
             putString(KEY_CUSTOM_MODEL_NAME, settings.customModelName)
             putString(KEY_STT_PROVIDER, settings.sttProvider.name)
@@ -314,7 +325,19 @@ class SettingsRepository(private val context: Context) {
     fun updateMistralApiKey(apiKey: String) {
         saveSettings(getSettings().copy(mistralApiKey = apiKey))
     }
-    
+
+    fun updateAnythingLlmServerUrl(url: String) {
+        saveSettings(getSettings().copy(anythingllmServerUrl = url))
+    }
+
+    fun updateAnythingLlmApiKey(apiKey: String) {
+        saveSettings(getSettings().copy(anythingllmApiKey = apiKey))
+    }
+
+    fun updateAnythingLlmWorkspaceSlug(slug: String) {
+        saveSettings(getSettings().copy(anythingllmWorkspaceSlug = slug))
+    }
+
     fun updateCustomApiKey(apiKey: String) {
         saveSettings(getSettings().copy(customApiKey = apiKey))
     }

--- a/phone-app/src/main/java/com/example/rokidphone/service/ai/AiServiceFactory.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/service/ai/AiServiceFactory.kt
@@ -1,7 +1,13 @@
 package com.example.rokidphone.service.ai
 
+import com.example.rokidphone.ai.provider.AnythingLLMProvider
+import com.example.rokidphone.ai.provider.ChatMessage
+import com.example.rokidphone.ai.provider.GenerationResult
+import com.example.rokidphone.ai.provider.MessageRole
+import com.example.rokidphone.ai.provider.ProviderSetting
 import com.example.rokidphone.data.AiProvider
 import com.example.rokidphone.data.ApiSettings
+import com.example.rokidphone.service.SpeechResult
 
 /**
  * AI Service Factory
@@ -174,6 +180,34 @@ object AiServiceFactory {
                 presencePenalty = settings.presencePenalty
             )
 
+            AiProvider.ANYTHINGLLM -> {
+                val providerSetting = ProviderSetting.AnythingLLM(
+                    serverUrl = settings.anythingllmServerUrl,
+                    apiKey = settings.anythingllmApiKey,
+                    workspaceSlug = settings.anythingllmWorkspaceSlug
+                )
+                val anythingLlmProvider = AnythingLLMProvider()
+                val history = mutableListOf<ChatMessage>()
+                object : AiServiceProvider {
+                    override val provider: AiProvider = AiProvider.ANYTHINGLLM
+                    override suspend fun transcribe(pcmAudioData: ByteArray, languageCode: String): SpeechResult =
+                        SpeechResult.Error("AnythingLLM does not support speech recognition")
+                    override suspend fun chat(userMessage: String): String {
+                        history.add(ChatMessage(MessageRole.USER, userMessage))
+                        return when (val result = anythingLlmProvider.generateText(providerSetting, history)) {
+                            is GenerationResult.Success -> {
+                                history.add(ChatMessage(MessageRole.ASSISTANT, result.text))
+                                result.text
+                            }
+                            is GenerationResult.Error -> "Error: ${result.message}"
+                        }
+                    }
+                    override suspend fun analyzeImage(imageData: ByteArray, prompt: String): String =
+                        "AnythingLLM does not support image analysis"
+                    override fun clearHistory() { history.clear() }
+                }
+            }
+
             AiProvider.GEMINI_LIVE -> {
                 // Gemini Live uses WebSocket streaming, not REST API.
                 // Return a standard GeminiService as fallback for non-live operations
@@ -196,7 +230,8 @@ object AiServiceFactory {
      */
     fun createTestService(settings: ApiSettings): OpenAiCompatibleService? {
         return when (settings.aiProvider) {
-            AiProvider.GEMINI, AiProvider.ANTHROPIC, AiProvider.BAIDU, AiProvider.GEMINI_LIVE -> null // Not OpenAI-compatible
+            AiProvider.GEMINI, AiProvider.ANTHROPIC, AiProvider.BAIDU,
+            AiProvider.GEMINI_LIVE, AiProvider.ANYTHINGLLM -> null // Not OpenAI-compatible
 
             AiProvider.DEEPSEEK -> DeepSeekService(
                 apiKey = settings.getCurrentApiKey(),

--- a/phone-app/src/main/java/com/example/rokidphone/ui/SettingsScreen.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ui/SettingsScreen.kt
@@ -26,6 +26,9 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.example.rokidphone.R
+import com.example.rokidphone.ai.provider.AnythingLLMProvider
+import com.example.rokidphone.ai.provider.ProviderSetting
+import com.example.rokidphone.ai.provider.ValidationResult
 import com.example.rokidphone.data.*
 import com.example.rokidphone.service.ai.AiServiceFactory
 import com.example.rokidphone.service.stt.SttProvider
@@ -125,9 +128,23 @@ fun SettingsScreen(
                     )
                 }
             }
-            
-            // API Key settings section (for non-custom providers)
-            if (settings.aiProvider != AiProvider.CUSTOM) {
+
+            // AnythingLLM Settings (only shown for ANYTHINGLLM provider)
+            if (settings.aiProvider == AiProvider.ANYTHINGLLM) {
+                item {
+                    AnythingLLMProviderSection(
+                        serverUrl = settings.anythingllmServerUrl,
+                        onServerUrlChange = { onSettingsChange(settings.copy(anythingllmServerUrl = it)) },
+                        apiKey = settings.anythingllmApiKey,
+                        onApiKeyChange = { onSettingsChange(settings.copy(anythingllmApiKey = it)) },
+                        workspaceSlug = settings.anythingllmWorkspaceSlug,
+                        onWorkspaceSlugChange = { onSettingsChange(settings.copy(anythingllmWorkspaceSlug = it)) }
+                    )
+                }
+            }
+
+            // API Key settings section (for non-custom, non-AnythingLLM providers)
+            if (settings.aiProvider != AiProvider.CUSTOM && settings.aiProvider != AiProvider.ANYTHINGLLM) {
                 item {
                                 SettingsSection(title = stringResource(R.string.api_keys)) {
                         when (settings.aiProvider) {
@@ -1456,6 +1473,172 @@ fun CustomProviderSection(
                                 stringResource(R.string.connection_success) 
                             else 
                                 result,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * AnythingLLM Provider Settings Section
+ */
+@Composable
+fun AnythingLLMProviderSection(
+    serverUrl: String,
+    onServerUrlChange: (String) -> Unit,
+    apiKey: String,
+    onApiKeyChange: (String) -> Unit,
+    workspaceSlug: String,
+    onWorkspaceSlugChange: (String) -> Unit
+) {
+    var isValidUrl by remember(serverUrl) {
+        mutableStateOf(serverUrl.startsWith("http://") || serverUrl.startsWith("https://"))
+    }
+    var isTesting by remember { mutableStateOf(false) }
+    var testResult by remember { mutableStateOf<String?>(null) }
+    var testSuccess by remember { mutableStateOf<Boolean?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.anythingllm_provider_settings),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Server URL
+            OutlinedTextField(
+                value = serverUrl,
+                onValueChange = {
+                    onServerUrlChange(it)
+                    isValidUrl = it.startsWith("http://") || it.startsWith("https://")
+                },
+                label = { Text(stringResource(R.string.anythingllm_server_url)) },
+                placeholder = { Text(stringResource(R.string.anythingllm_server_url_hint)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                isError = serverUrl.isNotBlank() && !isValidUrl,
+                supportingText = {
+                    if (serverUrl.isNotBlank() && !isValidUrl) {
+                        Text(stringResource(R.string.invalid_url), color = MaterialTheme.colorScheme.error)
+                    }
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri)
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // API Key
+            var passwordVisible by remember { mutableStateOf(false) }
+            OutlinedTextField(
+                value = apiKey,
+                onValueChange = onApiKeyChange,
+                label = { Text(stringResource(R.string.anythingllm_api_key)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                trailingIcon = {
+                    IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                        Icon(
+                            imageVector = if (passwordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                            contentDescription = if (passwordVisible) stringResource(R.string.hide) else stringResource(R.string.show)
+                        )
+                    }
+                }
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Workspace Slug
+            OutlinedTextField(
+                value = workspaceSlug,
+                onValueChange = onWorkspaceSlugChange,
+                label = { Text(stringResource(R.string.anythingllm_workspace_slug)) },
+                placeholder = { Text(stringResource(R.string.anythingllm_workspace_slug_hint)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Test Connection button
+            Button(
+                onClick = {
+                    isTesting = true
+                    testResult = null
+                    testSuccess = null
+                    coroutineScope.launch {
+                        if (serverUrl.isNotBlank() && !isValidUrl) {
+                            testSuccess = false
+                            testResult = context.getString(R.string.invalid_url)
+                        } else {
+                            val providerSetting = ProviderSetting.AnythingLLM(
+                                serverUrl = serverUrl,
+                                apiKey = apiKey,
+                                workspaceSlug = workspaceSlug
+                            )
+                            val result = AnythingLLMProvider().validateSetting(providerSetting)
+                            testSuccess = result is ValidationResult.Valid
+                            testResult = when (result) {
+                                is ValidationResult.Valid -> null
+                                is ValidationResult.Invalid -> result.reason
+                            }
+                        }
+                        isTesting = false
+                    }
+                },
+                enabled = !isTesting,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (isTesting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(R.string.testing_connection))
+                } else {
+                    Icon(Icons.Default.NetworkCheck, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(R.string.test_connection))
+                }
+            }
+
+            // Test result card
+            if (testSuccess != null || testResult != null) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = if (testSuccess == true)
+                            MaterialTheme.colorScheme.primaryContainer
+                        else
+                            MaterialTheme.colorScheme.errorContainer
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = if (testSuccess == true) Icons.Default.CheckCircle else Icons.Default.Error,
+                            contentDescription = null,
+                            tint = if (testSuccess == true) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = if (testSuccess == true)
+                                stringResource(R.string.connection_success)
+                            else
+                                testResult ?: "",
                             style = MaterialTheme.typography.bodyMedium
                         )
                     }

--- a/phone-app/src/main/java/com/example/rokidphone/ui/SettingsScreen.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ui/SettingsScreen.kt
@@ -1501,7 +1501,7 @@ fun AnythingLLMProviderSection(
     var testResult by remember { mutableStateOf<String?>(null) }
     var testSuccess by remember { mutableStateOf<Boolean?>(null) }
     val coroutineScope = rememberCoroutineScope()
-    val context = LocalContext.current
+    val invalidUrlText = stringResource(R.string.invalid_url)
 
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -1578,7 +1578,7 @@ fun AnythingLLMProviderSection(
                     coroutineScope.launch {
                         if (serverUrl.isNotBlank() && !isValidUrl) {
                             testSuccess = false
-                            testResult = context.getString(R.string.invalid_url)
+                            testResult = invalidUrlText
                         } else {
                             val providerSetting = ProviderSetting.AnythingLLM(
                                 serverUrl = serverUrl,

--- a/phone-app/src/main/res/values/strings.xml
+++ b/phone-app/src/main/res/values/strings.xml
@@ -166,8 +166,16 @@
     <string name="perplexity_api_key">Perplexity API Key</string>
     <string name="moonshot_api_key">Moonshot API Key</string>
     <string name="mistral_api_key" translatable="false">Mistral API Key</string>
+    <string name="anythingllm_api_key" translatable="false">AnythingLLM API Key</string>
     <string name="custom_api_key">Custom API Key (Optional)</string>
-    
+
+    <!-- AnythingLLM Provider Settings -->
+    <string name="anythingllm_provider_settings" translatable="false">AnythingLLM Settings</string>
+    <string name="anythingllm_server_url" translatable="false">Server URL</string>
+    <string name="anythingllm_server_url_hint" translatable="false">e.g., http://localhost:3001</string>
+    <string name="anythingllm_workspace_slug" translatable="false">Workspace Slug</string>
+    <string name="anythingllm_workspace_slug_hint" translatable="false">e.g., my-workspace</string>
+
     <!-- Custom Provider Settings -->
     <string name="custom_provider_settings">Custom Provider Settings</string>
     <string name="base_url">Base URL</string>
@@ -202,6 +210,7 @@
     <string name="provider_perplexity">Perplexity</string>
     <string name="provider_moonshot">Moonshot (Kimi)</string>
     <string name="provider_mistral" translatable="false">Mistral AI</string>
+    <string name="provider_anythingllm" translatable="false">AnythingLLM</string>
     <string name="provider_custom">Custom / Self-Hosted</string>
     <string name="provider_gemini_live">Gemini Live</string>
     

--- a/phone-app/src/test/java/com/example/rokidphone/ai/provider/AnythingLLMProviderTest.kt
+++ b/phone-app/src/test/java/com/example/rokidphone/ai/provider/AnythingLLMProviderTest.kt
@@ -1,0 +1,372 @@
+package com.example.rokidphone.ai.provider
+
+import com.example.rokidphone.testutil.MockWebServerRule
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import okhttp3.Headers.Companion.headersOf
+import org.json.JSONObject
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit tests for AnythingLLMProvider.
+ * Covers chat relay, citation mapping, auth failure, connection failure, and isValid().
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnythingLLMProviderTest {
+
+    @get:Rule
+    val mockServer = MockWebServerRule()
+
+    private val provider = AnythingLLMProvider()
+
+    private fun validSetting(slug: String = "my-workspace") = ProviderSetting.AnythingLLM(
+        serverUrl = mockServer.baseUrlNoSlash,
+        apiKey = "test-api-key",
+        workspaceSlug = slug
+    )
+
+    private fun jsonResponse(body: String, code: Int = 200) = MockResponse(
+        code = code,
+        body = body,
+        headers = headersOf("Content-Type", "application/json")
+    )
+
+    private fun chatSuccessResponse(text: String, sources: String = "[]") = """
+        {
+          "textResponse": "$text",
+          "sources": $sources
+        }
+    """.trimIndent()
+
+    // ==================== Successful Chat Relay ====================
+
+    @Test
+    fun `generateText - sends POST to correct workspace path`() = runTest {
+        mockServer.server.enqueue(jsonResponse(chatSuccessResponse("Hello!")))
+
+        provider.generateText(
+            setting = validSetting(slug = "test-slug"),
+            messages = listOf(ChatMessage(MessageRole.USER, "Hi"))
+        )
+
+        val request = mockServer.server.takeRequest()
+        assertThat(request.method).isEqualTo("POST")
+        assertThat(request.path).isEqualTo("/api/v1/workspace/test-slug/chat")
+    }
+
+    @Test
+    fun `generateText - request body contains mode chat and user message`() = runTest {
+        mockServer.server.enqueue(jsonResponse(chatSuccessResponse("Response")))
+
+        provider.generateText(
+            setting = validSetting(),
+            messages = listOf(ChatMessage(MessageRole.USER, "What is RAG?"))
+        )
+
+        val request = mockServer.server.takeRequest()
+        val body = JSONObject(request.body.readUtf8())
+        assertThat(body.getString("mode")).isEqualTo("chat")
+        assertThat(body.getString("message")).isEqualTo("What is RAG?")
+    }
+
+    @Test
+    fun `generateText - request sends Bearer token`() = runTest {
+        mockServer.server.enqueue(jsonResponse(chatSuccessResponse("Hi")))
+
+        provider.generateText(
+            setting = validSetting(),
+            messages = listOf(ChatMessage(MessageRole.USER, "Hello"))
+        )
+
+        val request = mockServer.server.takeRequest()
+        assertThat(request.headers["Authorization"]).isEqualTo("Bearer test-api-key")
+    }
+
+    @Test
+    fun `generateText - returns textResponse from response body`() = runTest {
+        mockServer.server.enqueue(jsonResponse(chatSuccessResponse("Workspace answer")))
+
+        val result = provider.generateText(
+            setting = validSetting(),
+            messages = listOf(ChatMessage(MessageRole.USER, "Tell me something"))
+        )
+
+        assertThat(result).isInstanceOf(GenerationResult.Success::class.java)
+        val text = (result as GenerationResult.Success).text
+        assertThat(text).startsWith("Workspace answer")
+    }
+
+    @Test
+    fun `generateText - falls back to response field when textResponse is blank`() = runTest {
+        val responseBody = """{"textResponse": "", "response": "Fallback text", "sources": []}"""
+        mockServer.server.enqueue(jsonResponse(responseBody))
+
+        val result = provider.generateText(
+            setting = validSetting(),
+            messages = listOf(ChatMessage(MessageRole.USER, "Test"))
+        )
+
+        assertThat(result).isInstanceOf(GenerationResult.Success::class.java)
+        assertThat((result as GenerationResult.Success).text).startsWith("Fallback text")
+    }
+
+    @Test
+    fun `generateText - uses last USER message when history present`() = runTest {
+        mockServer.server.enqueue(jsonResponse(chatSuccessResponse("OK")))
+
+        provider.generateText(
+            setting = validSetting(),
+            messages = listOf(
+                ChatMessage(MessageRole.USER, "First message"),
+                ChatMessage(MessageRole.ASSISTANT, "First reply"),
+                ChatMessage(MessageRole.USER, "Second message")
+            )
+        )
+
+        val body = JSONObject(mockServer.server.takeRequest().body.readUtf8())
+        assertThat(body.getString("message")).isEqualTo("Second message")
+    }
+
+    // ==================== Citation Mapping ====================
+
+    @Test
+    fun `generateText - appends sources with title and url`() = runTest {
+        val sources = """[{"title":"Doc1","url":"https://example.com/doc1","score":0.92}]"""
+        mockServer.server.enqueue(jsonResponse(chatSuccessResponse("Answer text", sources)))
+
+        val result = provider.generateText(
+            setting = validSetting(),
+            messages = listOf(ChatMessage(MessageRole.USER, "Query"))
+        ) as GenerationResult.Success
+
+        assertThat(result.text).contains("**Sources:**")
+        assertThat(result.text).contains("Doc1")
+        assertThat(result.text).contains("https://example.com/doc1")
+        assertThat(result.text).contains("[score: 0.92]")
+    }
+
+    @Test
+    fun `generateText - appends sources with chunkSource when url is missing`() = runTest {
+        val sources = """[{"title":"Doc2","chunkSource":"file://docs/notes.txt","score":0.75}]"""
+        mockServer.server.enqueue(jsonResponse(chatSuccessResponse("Answer", sources)))
+
+        val result = provider.generateText(
+            setting = validSetting(),
+            messages = listOf(ChatMessage(MessageRole.USER, "Query"))
+        ) as GenerationResult.Success
+
+        assertThat(result.text).contains("Doc2")
+        assertThat(result.text).contains("file://docs/notes.txt")
+        assertThat(result.text).contains("[score: 0.75]")
+    }
+
+    @Test
+    fun `generateText - multiple sources all appear in output`() = runTest {
+        val sources = """[
+            {"title":"DocA","url":"https://a.com","score":0.9},
+            {"title":"DocB","url":"https://b.com","score":0.8}
+        ]"""
+        mockServer.server.enqueue(jsonResponse(chatSuccessResponse("Multi-source answer", sources)))
+
+        val result = provider.generateText(
+            setting = validSetting(),
+            messages = listOf(ChatMessage(MessageRole.USER, "Query"))
+        ) as GenerationResult.Success
+
+        assertThat(result.text).contains("DocA")
+        assertThat(result.text).contains("DocB")
+        assertThat(result.text).contains("https://a.com")
+        assertThat(result.text).contains("https://b.com")
+    }
+
+    @Test
+    fun `generateText - empty sources array does not append sources section`() = runTest {
+        mockServer.server.enqueue(jsonResponse(chatSuccessResponse("Clean answer", "[]")))
+
+        val result = provider.generateText(
+            setting = validSetting(),
+            messages = listOf(ChatMessage(MessageRole.USER, "Query"))
+        ) as GenerationResult.Success
+
+        assertThat(result.text).doesNotContain("**Sources:**")
+    }
+
+    // ==================== Auth Failure (validateSetting) ====================
+
+    @Test
+    fun `validateSetting - returns Valid on 200 OK`() = runTest {
+        mockServer.server.enqueue(jsonResponse("""{"authenticated": true}"""))
+
+        val result = provider.validateSetting(validSetting())
+
+        assertThat(result).isEqualTo(ValidationResult.Valid)
+    }
+
+    @Test
+    fun `validateSetting - sends GET to auth endpoint with Bearer token`() = runTest {
+        mockServer.server.enqueue(jsonResponse("""{"authenticated": true}"""))
+
+        provider.validateSetting(validSetting())
+
+        val request = mockServer.server.takeRequest()
+        assertThat(request.method).isEqualTo("GET")
+        assertThat(request.path).isEqualTo("/api/v1/auth")
+        assertThat(request.headers["Authorization"]).isEqualTo("Bearer test-api-key")
+    }
+
+    @Test
+    fun `validateSetting - returns Invalid with apiKey field on 401`() = runTest {
+        mockServer.server.enqueue(MockResponse(code = 401))
+
+        val result = provider.validateSetting(validSetting())
+
+        assertThat(result).isInstanceOf(ValidationResult.Invalid::class.java)
+        val invalid = result as ValidationResult.Invalid
+        assertThat(invalid.field).isEqualTo("apiKey")
+        assertThat(invalid.reason).contains("authentication failed")
+    }
+
+    @Test
+    fun `validateSetting - returns Invalid with HTTP code message on non-401 error`() = runTest {
+        mockServer.server.enqueue(MockResponse(code = 503))
+
+        val result = provider.validateSetting(validSetting())
+
+        assertThat(result).isInstanceOf(ValidationResult.Invalid::class.java)
+        assertThat((result as ValidationResult.Invalid).reason).contains("503")
+    }
+
+    @Test
+    fun `validateSetting - returns Invalid early when setting is invalid`() = runTest {
+        val incompleteSetting = ProviderSetting.AnythingLLM(
+            serverUrl = mockServer.baseUrlNoSlash,
+            apiKey = "",
+            workspaceSlug = "slug"
+        )
+
+        val result = provider.validateSetting(incompleteSetting)
+
+        assertThat(result).isInstanceOf(ValidationResult.Invalid::class.java)
+        assertThat((result as ValidationResult.Invalid).field).isEqualTo("apiKey")
+        // No HTTP request should have been made
+        assertThat(mockServer.server.requestCount).isEqualTo(0)
+    }
+
+    // ==================== Connection Failure ====================
+
+    @Test
+    fun `generateText - returns Error result when server is unreachable`() = runTest {
+        val result = provider.generateText(
+            setting = ProviderSetting.AnythingLLM(
+                serverUrl = "http://127.0.0.1:1",
+                apiKey = "key",
+                workspaceSlug = "slug"
+            ),
+            messages = listOf(ChatMessage(MessageRole.USER, "Hello"))
+        )
+
+        assertThat(result).isInstanceOf(GenerationResult.Error::class.java)
+        val error = result as GenerationResult.Error
+        assertThat(error.retryable).isTrue()
+    }
+
+    @Test
+    fun `validateSetting - returns Invalid when server is unreachable`() = runTest {
+        val result = provider.validateSetting(
+            ProviderSetting.AnythingLLM(
+                serverUrl = "http://127.0.0.1:1",
+                apiKey = "key",
+                workspaceSlug = "slug"
+            )
+        )
+
+        assertThat(result).isInstanceOf(ValidationResult.Invalid::class.java)
+        assertThat((result as ValidationResult.Invalid).reason).contains("Connection failed")
+    }
+
+    @Test
+    fun `generateText - returns Error on HTTP 500`() = runTest {
+        mockServer.server.enqueue(MockResponse(code = 500))
+
+        val result = provider.generateText(
+            setting = validSetting(),
+            messages = listOf(ChatMessage(MessageRole.USER, "Query"))
+        )
+
+        assertThat(result).isInstanceOf(GenerationResult.Error::class.java)
+        val error = result as GenerationResult.Error
+        assertThat(error.message).contains("500")
+        assertThat(error.retryable).isTrue()
+    }
+
+    // ==================== isValid() ====================
+
+    @Test
+    fun `isValid returns true when all three fields are non-blank`() {
+        val setting = ProviderSetting.AnythingLLM(
+            serverUrl = "http://localhost:3001",
+            apiKey = "my-key",
+            workspaceSlug = "workspace"
+        )
+        assertThat(setting.isValid()).isTrue()
+    }
+
+    @Test
+    fun `isValid returns false when serverUrl is blank`() {
+        val setting = ProviderSetting.AnythingLLM(serverUrl = "", apiKey = "key", workspaceSlug = "slug")
+        assertThat(setting.isValid()).isFalse()
+    }
+
+    @Test
+    fun `isValid returns false when apiKey is blank`() {
+        val setting = ProviderSetting.AnythingLLM(serverUrl = "http://host", apiKey = "", workspaceSlug = "slug")
+        assertThat(setting.isValid()).isFalse()
+    }
+
+    @Test
+    fun `isValid returns false when workspaceSlug is blank`() {
+        val setting = ProviderSetting.AnythingLLM(serverUrl = "http://host", apiKey = "key", workspaceSlug = "")
+        assertThat(setting.isValid()).isFalse()
+    }
+
+    @Test
+    fun `isValid returns false when all fields are blank`() {
+        val setting = ProviderSetting.AnythingLLM()
+        assertThat(setting.isValid()).isFalse()
+    }
+
+    // ==================== Unsupported operations ====================
+
+    @Test
+    fun `analyzeImage returns error indicating no image support`() = runTest {
+        val result = provider.analyzeImage(validSetting(), byteArrayOf(), "prompt")
+
+        assertThat(result).isInstanceOf(GenerationResult.Error::class.java)
+        assertThat((result as GenerationResult.Error).message).contains("does not support image analysis")
+    }
+
+    @Test
+    fun `transcribe returns error indicating no speech support`() = runTest {
+        val result = provider.transcribe(validSetting(), byteArrayOf())
+
+        assertThat(result).isInstanceOf(TranscriptionResult.Error::class.java)
+        assertThat((result as TranscriptionResult.Error).message).contains("does not support speech recognition")
+    }
+
+    @Test
+    fun `listModels returns empty list`() = runTest {
+        val models = provider.listModels(validSetting())
+        assertThat(models).isEmpty()
+    }
+
+    // ==================== Provider metadata ====================
+
+    @Test
+    fun `providerId is anythingllm`() {
+        assertThat(provider.providerId).isEqualTo("anythingllm")
+    }
+}

--- a/phone-app/src/test/java/com/example/rokidphone/ai/provider/ProviderSettingTest.kt
+++ b/phone-app/src/test/java/com/example/rokidphone/ai/provider/ProviderSettingTest.kt
@@ -115,6 +115,54 @@ class ProviderSettingTest {
         assertThat(setting.isValid()).isFalse()
     }
 
+    // ==================== AnythingLLM Validation AnythingLLM 驗證 ====================
+
+    @Test
+    fun `AnythingLLM isValid returns true when all three fields are not blank`() {
+        val setting = ProviderSetting.AnythingLLM(
+            serverUrl = "http://localhost:3001",
+            apiKey = "my-key",
+            workspaceSlug = "workspace"
+        )
+        assertThat(setting.isValid()).isTrue()
+    }
+
+    @Test
+    fun `AnythingLLM isValid returns false when serverUrl is blank`() {
+        val setting = ProviderSetting.AnythingLLM(serverUrl = "", apiKey = "key", workspaceSlug = "slug")
+        assertThat(setting.isValid()).isFalse()
+    }
+
+    @Test
+    fun `AnythingLLM isValid returns false when apiKey is blank`() {
+        val setting = ProviderSetting.AnythingLLM(serverUrl = "http://host", apiKey = "", workspaceSlug = "slug")
+        assertThat(setting.isValid()).isFalse()
+    }
+
+    @Test
+    fun `AnythingLLM isValid returns false when workspaceSlug is blank`() {
+        val setting = ProviderSetting.AnythingLLM(serverUrl = "http://host", apiKey = "key", workspaceSlug = "")
+        assertThat(setting.isValid()).isFalse()
+    }
+
+    @Test
+    fun `AnythingLLM has correct default values`() {
+        val setting = ProviderSetting.AnythingLLM()
+        assertThat(setting.id).isEqualTo("anythingllm")
+        assertThat(setting.displayName).isEqualTo("AnythingLLM")
+        assertThat(setting.enabled).isTrue()
+        assertThat(setting.serverUrl).isEmpty()
+        assertThat(setting.apiKey).isEmpty()
+        assertThat(setting.workspaceSlug).isEmpty()
+        assertThat(setting.providerBaseUrl).isEmpty()
+    }
+
+    @Test
+    fun `AnythingLLM providerApiKey reflects apiKey`() {
+        val setting = ProviderSetting.AnythingLLM(apiKey = "ak-secret")
+        assertThat(setting.providerApiKey).isEqualTo("ak-secret")
+    }
+
     // ==================== Custom Provider Validation 自訂供應商驗證 ====================
 
     @Test
@@ -218,6 +266,7 @@ class ProviderSettingTest {
         assertThat(ProviderSetting.fromId("baidu")).isInstanceOf(ProviderSetting.Baidu::class.java)
         assertThat(ProviderSetting.fromId("perplexity")).isInstanceOf(ProviderSetting.Perplexity::class.java)
         assertThat(ProviderSetting.fromId("moonshot")).isInstanceOf(ProviderSetting.Moonshot::class.java)
+        assertThat(ProviderSetting.fromId("anythingllm")).isInstanceOf(ProviderSetting.AnythingLLM::class.java)
         assertThat(ProviderSetting.fromId("custom")).isInstanceOf(ProviderSetting.Custom::class.java)
     }
 
@@ -232,10 +281,10 @@ class ProviderSettingTest {
     // ==================== getDefaultProviders() Tests ====================
 
     @Test
-    fun `getDefaultProviders returns exactly 12 providers`() {
-        // 預設供應商清單應包含 13 個供應商（新增 Mistral）
+    fun `getDefaultProviders returns exactly 14 providers`() {
+        // 預設供應商清單應包含 14 個供應商（新增 AnythingLLM）
         val providers = ProviderSetting.getDefaultProviders()
-        assertThat(providers).hasSize(13)
+        assertThat(providers).hasSize(14)
     }
 
     @Test
@@ -263,6 +312,7 @@ class ProviderSettingTest {
             ProviderSetting.Perplexity::class,
             ProviderSetting.Moonshot::class,
             ProviderSetting.Mistral::class,
+            ProviderSetting.AnythingLLM::class,
             ProviderSetting.Custom::class
         ).inOrder()
     }
@@ -284,8 +334,10 @@ class ProviderSettingTest {
 
     @Test
     fun `all default providers have non-blank baseUrl`() {
-        ProviderSetting.getDefaultProviders().forEach { provider ->
-            assertThat(provider.providerBaseUrl).isNotEmpty()
-        }
+        ProviderSetting.getDefaultProviders()
+            .filterNot { it is ProviderSetting.AnythingLLM }
+            .forEach { provider ->
+                assertThat(provider.providerBaseUrl).isNotEmpty()
+            }
     }
 }


### PR DESCRIPTION
Closes #5

Summary:
- Add ProviderSetting.AnythingLLM and wire it into provider defaults, settings storage, provider selection, and service creation.
- Add an AnythingLLM provider adapter for auth validation and workspace chat relay with source previews.
- Add Settings UI fields for server URL, API key, workspace slug, and Test connection.
- Add MockWebServer unit tests for chat, sources, auth failure, connection failure, and validation.

Non-goals kept out of scope:
- No redesign of overall product flow.
- No answer-mode architecture changes.
- No history metadata or badge changes.
- No photo-to-docs routing changes.
- No major UI restructuring.
- No NetworkClientFactory or BaseAiService refactor.
- Existing users remain unchanged unless they opt into AnythingLLM from the provider selector.

Verification:
- .\gradlew.bat --no-daemon --console=plain :phone-app:assembleDebug
- .\gradlew.bat --no-daemon --console=plain :phone-app:testDebugUnitTest