### PR TITLE
feat: single-request voice flow for Private Server + video support

### DIFF
--- a/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderManager.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderManager.kt
@@ -143,6 +143,7 @@ class ProviderManager private constructor(
             AiProvider.PERPLEXITY -> settingsRepository.updatePerplexityApiKey(apiKey)
             AiProvider.MOONSHOT -> settingsRepository.updateMoonshotApiKey(apiKey)
             AiProvider.GEMINI_LIVE -> settingsRepository.updateGeminiApiKey(apiKey)  // Shares Gemini API key
+            AiProvider.VPS -> { /* VPS uses auth token, configured via settings */ }
             AiProvider.CUSTOM -> settingsRepository.updateCustomApiKey(apiKey)
         }
         cachedService = null
@@ -222,6 +223,10 @@ class ProviderManager private constructor(
                 apiKey = settings.moonshotApiKey,
                 modelId = settings.aiModelId
             )
+            AiProvider.VPS -> ProviderSetting.Vps(
+                baseUrl = settings.vpsBaseUrl,
+                authToken = settings.vpsAuthToken
+            )
             AiProvider.CUSTOM -> ProviderSetting.Custom(
                 apiKey = settings.customApiKey,
                 modelId = settings.customModelName,
@@ -274,6 +279,12 @@ class ProviderManager private constructor(
             }
             if (settings.moonshotApiKey.isNotBlank()) {
                 add(ProviderSetting.Moonshot(apiKey = settings.moonshotApiKey))
+            }
+            if (settings.vpsBaseUrl.isNotBlank()) {
+                add(ProviderSetting.Vps(
+                    baseUrl = settings.vpsBaseUrl,
+                    authToken = settings.vpsAuthToken
+                ))
             }
             if (settings.customBaseUrl.isNotBlank()) {
                 add(ProviderSetting.Custom(

--- a/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderManager.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderManager.kt
@@ -143,7 +143,7 @@ class ProviderManager private constructor(
             AiProvider.PERPLEXITY -> settingsRepository.updatePerplexityApiKey(apiKey)
             AiProvider.MOONSHOT -> settingsRepository.updateMoonshotApiKey(apiKey)
             AiProvider.GEMINI_LIVE -> settingsRepository.updateGeminiApiKey(apiKey)  // Shares Gemini API key
-            AiProvider.VPS -> { /* VPS uses auth token, configured via settings */ }
+            AiProvider.PRIVATE_SERVER -> { /* VPS uses auth token, configured via settings */ }
             AiProvider.CUSTOM -> settingsRepository.updateCustomApiKey(apiKey)
         }
         cachedService = null
@@ -223,9 +223,9 @@ class ProviderManager private constructor(
                 apiKey = settings.moonshotApiKey,
                 modelId = settings.aiModelId
             )
-            AiProvider.VPS -> ProviderSetting.Vps(
-                baseUrl = settings.vpsBaseUrl,
-                authToken = settings.vpsAuthToken
+            AiProvider.PRIVATE_SERVER -> ProviderSetting.PrivateServer(
+                baseUrl = settings.privateServerUrl,
+                authToken = settings.privateServerToken
             )
             AiProvider.CUSTOM -> ProviderSetting.Custom(
                 apiKey = settings.customApiKey,
@@ -280,10 +280,10 @@ class ProviderManager private constructor(
             if (settings.moonshotApiKey.isNotBlank()) {
                 add(ProviderSetting.Moonshot(apiKey = settings.moonshotApiKey))
             }
-            if (settings.vpsBaseUrl.isNotBlank()) {
-                add(ProviderSetting.Vps(
-                    baseUrl = settings.vpsBaseUrl,
-                    authToken = settings.vpsAuthToken
+            if (settings.privateServerUrl.isNotBlank()) {
+                add(ProviderSetting.PrivateServer(
+                    baseUrl = settings.privateServerUrl,
+                    authToken = settings.privateServerToken
                 ))
             }
             if (settings.customBaseUrl.isNotBlank()) {

--- a/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderSetting.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderSetting.kt
@@ -243,6 +243,25 @@ sealed class ProviderSetting {
     }
     
     /**
+     * VPS Provider Settings
+     * Personal VPS running Claude Code for photo analysis + voice
+     */
+    @Serializable
+    data class Vps(
+        override val id: String = "vps",
+        override val displayName: String = "Personal VPS",
+        override val enabled: Boolean = true,
+        val baseUrl: String = "http://100.108.124.60:8081",
+        val authToken: String = ""
+    ) : ProviderSetting() {
+        @Transient
+        override val providerApiKey: String? = authToken.ifBlank { null }
+        @Transient
+        override val providerBaseUrl: String = baseUrl
+        override fun isValid(): Boolean = baseUrl.isNotBlank()
+    }
+
+    /**
      * Custom OpenAI-compatible Provider Settings
      * Supports Ollama, LM Studio, vLLM, and other local deployments
      */
@@ -279,6 +298,7 @@ sealed class ProviderSetting {
             Baidu(),
             Perplexity(),
             Moonshot(),
+            Vps(),
             Custom()
         )
         
@@ -297,6 +317,7 @@ sealed class ProviderSetting {
             "baidu" -> Baidu()
             "perplexity" -> Perplexity()
             "moonshot" -> Moonshot()
+            "vps" -> Vps()
             "custom" -> Custom()
             else -> null
         }

--- a/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderSetting.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ai/provider/ProviderSetting.kt
@@ -243,15 +243,16 @@ sealed class ProviderSetting {
     }
     
     /**
-     * VPS Provider Settings
-     * Personal VPS running Claude Code for photo analysis + voice
+     * Private Server Provider Settings
+     * Self-hosted server with photo analysis + voice endpoints.
+     * Base URL must be configured in settings (no default).
      */
     @Serializable
-    data class Vps(
-        override val id: String = "vps",
-        override val displayName: String = "Personal VPS",
+    data class PrivateServer(
+        override val id: String = "private_server",
+        override val displayName: String = "Private Server",
         override val enabled: Boolean = true,
-        val baseUrl: String = "http://100.108.124.60:8081",
+        val baseUrl: String = "",
         val authToken: String = ""
     ) : ProviderSetting() {
         @Transient
@@ -298,7 +299,7 @@ sealed class ProviderSetting {
             Baidu(),
             Perplexity(),
             Moonshot(),
-            Vps(),
+            PrivateServer(),
             Custom()
         )
         
@@ -317,7 +318,7 @@ sealed class ProviderSetting {
             "baidu" -> Baidu()
             "perplexity" -> Perplexity()
             "moonshot" -> Moonshot()
-            "vps" -> Vps()
+            "vps" -> PrivateServer()
             "custom" -> Custom()
             else -> null
         }

--- a/phone-app/src/main/java/com/example/rokidphone/data/ApiSettings.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/data/ApiSettings.kt
@@ -124,6 +124,15 @@ enum class AiProvider(
         supportsSpeech = true,
         supportsVision = true
     ),
+    VPS(
+        displayNameResId = R.string.provider_vps,
+        description = "Personal VPS running Claude Code — photo analysis + voice",
+        website = "",
+        defaultBaseUrl = "http://100.108.124.60:8081",
+        isOpenAiCompatible = false,
+        supportsSpeech = false,
+        supportsVision = true
+    ),
     CUSTOM(
         displayNameResId = R.string.provider_custom,
         description = "OpenAI-compatible API (Ollama, LM Studio, etc.)",
@@ -724,6 +733,10 @@ data class ApiSettings(
     val moonshotApiKey: String = "",
     val customApiKey: String = "",
     
+    // VPS settings
+    val vpsBaseUrl: String = "http://100.108.124.60:8081",
+    val vpsAuthToken: String = "",
+
     // Custom base URLs (for providers that support it)
     val customBaseUrl: String = "http://localhost:11434/v1/",
     val customModelName: String = "llama4",
@@ -850,7 +863,8 @@ data class ApiSettings(
             AiProvider.BAIDU -> baiduApiKey
             AiProvider.PERPLEXITY -> perplexityApiKey
             AiProvider.MOONSHOT -> moonshotApiKey
-            AiProvider.GEMINI_LIVE -> geminiApiKey  // Shares Gemini API key
+            AiProvider.GEMINI_LIVE -> geminiApiKey
+            AiProvider.VPS -> vpsAuthToken
             AiProvider.CUSTOM -> customApiKey
         }
     }
@@ -871,11 +885,12 @@ data class ApiSettings(
             AiProvider.BAIDU -> baiduApiKey
             AiProvider.PERPLEXITY -> perplexityApiKey
             AiProvider.MOONSHOT -> moonshotApiKey
-            AiProvider.GEMINI_LIVE -> geminiApiKey  // Shares Gemini API key
+            AiProvider.GEMINI_LIVE -> geminiApiKey
+            AiProvider.VPS -> vpsAuthToken
             AiProvider.CUSTOM -> customApiKey
         }
     }
-    
+
     /**
      * Get base URL for current provider
      */
@@ -903,6 +918,7 @@ data class ApiSettings(
         return when (aiProvider) {
             AiProvider.CUSTOM -> customBaseUrl.isNotBlank() && isValidUrl(customBaseUrl)
             AiProvider.BAIDU -> baiduApiKey.isNotBlank() && baiduSecretKey.isNotBlank()
+            AiProvider.VPS -> vpsBaseUrl.isNotBlank() && isValidUrl(vpsBaseUrl)
             else -> getCurrentApiKey().isNotBlank()
         }
     }

--- a/phone-app/src/main/java/com/example/rokidphone/data/ApiSettings.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/data/ApiSettings.kt
@@ -124,11 +124,11 @@ enum class AiProvider(
         supportsSpeech = true,
         supportsVision = true
     ),
-    VPS(
-        displayNameResId = R.string.provider_vps,
-        description = "Personal VPS running Claude Code — photo analysis + voice",
+    PRIVATE_SERVER(
+        displayNameResId = R.string.provider_private_server,
+        description = "Self-hosted server with photo analysis + voice endpoints",
         website = "",
-        defaultBaseUrl = "http://100.108.124.60:8081",
+        defaultBaseUrl = "",
         isOpenAiCompatible = false,
         supportsSpeech = false,
         supportsVision = true
@@ -733,9 +733,9 @@ data class ApiSettings(
     val moonshotApiKey: String = "",
     val customApiKey: String = "",
     
-    // VPS settings
-    val vpsBaseUrl: String = "http://100.108.124.60:8081",
-    val vpsAuthToken: String = "",
+    // Private server settings (self-hosted AI endpoint)
+    val privateServerUrl: String = "",
+    val privateServerToken: String = "",
 
     // Custom base URLs (for providers that support it)
     val customBaseUrl: String = "http://localhost:11434/v1/",
@@ -864,7 +864,7 @@ data class ApiSettings(
             AiProvider.PERPLEXITY -> perplexityApiKey
             AiProvider.MOONSHOT -> moonshotApiKey
             AiProvider.GEMINI_LIVE -> geminiApiKey
-            AiProvider.VPS -> vpsAuthToken
+            AiProvider.PRIVATE_SERVER -> privateServerToken
             AiProvider.CUSTOM -> customApiKey
         }
     }
@@ -886,7 +886,7 @@ data class ApiSettings(
             AiProvider.PERPLEXITY -> perplexityApiKey
             AiProvider.MOONSHOT -> moonshotApiKey
             AiProvider.GEMINI_LIVE -> geminiApiKey
-            AiProvider.VPS -> vpsAuthToken
+            AiProvider.PRIVATE_SERVER -> privateServerToken
             AiProvider.CUSTOM -> customApiKey
         }
     }
@@ -918,7 +918,7 @@ data class ApiSettings(
         return when (aiProvider) {
             AiProvider.CUSTOM -> customBaseUrl.isNotBlank() && isValidUrl(customBaseUrl)
             AiProvider.BAIDU -> baiduApiKey.isNotBlank() && baiduSecretKey.isNotBlank()
-            AiProvider.VPS -> vpsBaseUrl.isNotBlank() && isValidUrl(vpsBaseUrl)
+            AiProvider.PRIVATE_SERVER -> privateServerUrl.isNotBlank() && isValidUrl(privateServerUrl)
             else -> getCurrentApiKey().isNotBlank()
         }
     }

--- a/phone-app/src/main/java/com/example/rokidphone/service/PhoneAIService.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/service/PhoneAIService.kt
@@ -23,6 +23,7 @@ import com.example.rokidphone.data.db.RecordingRepository
 import com.example.rokidphone.service.ai.AiServiceFactory
 import com.example.rokidphone.service.ai.AiServiceProvider
 import com.example.rokidphone.service.ai.GeminiLiveSession
+import com.example.rokidphone.service.ai.PrivateServerService
 import com.example.rokidphone.service.cxr.CxrMobileManager
 import com.example.rokidphone.service.stt.SttProvider
 import com.example.rokidphone.service.stt.SttService
@@ -547,8 +548,10 @@ class PhoneAIService : Service() {
                     return
                 }
                 
-                // Check STT service availability before allowing recording
-                if (sttService == null && speechService == null) {
+                // Check STT service availability before allowing recording.
+                // Private Server handles STT on the server side — no local STT needed.
+                val isPrivateServer = aiService is PrivateServerService
+                if (!isPrivateServer && sttService == null && speechService == null) {
                     Log.e(TAG, "STT service not available - API key not configured")
                     val errorMsg = getString(R.string.service_not_ready)
                     bluetoothManager?.sendMessage(Message.aiError(errorMsg))
@@ -695,9 +698,15 @@ class PhoneAIService : Service() {
                 payload = cleanedResult
             ))
             
-            // TTS voice playback
-            ttsService?.speak(cleanedResult) { }
-            
+            // TTS voice playback — use VPS audio if Private Server, otherwise local TTS
+            val privateServer = aiService as? PrivateServerService
+            val vpsAudio = privateServer?.lastAudioResponse
+            if (vpsAudio != null && vpsAudio.isNotEmpty()) {
+                playAudioResponse(vpsAudio)
+            } else {
+                ttsService?.speak(cleanedResult) { }
+            }
+
         } catch (e: Exception) {
             Log.e(TAG, "Failed to analyze photo", e)
             bluetoothManager?.sendMessage(Message.aiError(
@@ -711,6 +720,16 @@ class PhoneAIService : Service() {
      */
     private suspend fun processVoiceData(audioData: ByteArray) {
         try {
+            val settings = SettingsRepository.getInstance(this).getSettings()
+
+            // Private Server: single-request flow (audio -> VPS -> STT + Claude + TTS)
+            if (aiService is PrivateServerService) {
+                processVoiceDataViaPrivateServer(audioData, settings)
+                return
+            }
+
+            // Standard flow: local STT -> AI chat -> local TTS
+
             // Check if any speech service is available
             if (sttService == null && speechService == null) {
                 Log.e(TAG, "Speech service not available - no API key configured")
@@ -720,17 +739,15 @@ class PhoneAIService : Service() {
                     type = MessageType.AI_ERROR,
                     payload = errorMsg
                 ))
-                // Notify UI to show settings prompt
                 notifyApiKeyMissing()
                 return
             }
-            
+
             // 1. Notify glasses: recognizing
             bluetoothManager?.sendMessage(Message.aiProcessing(getString(R.string.recognizing_speech)))
-            
+
             // 2. Speech recognition - prefer dedicated STT service if available
             Log.d(TAG, "Starting speech recognition...")
-            val settings = SettingsRepository.getInstance(this).getSettings()
             val transcriptResult = if (sttService != null) {
                 Log.d(TAG, "Using dedicated STT service: ${sttService?.provider?.name}")
                 sttService?.transcribe(audioData, settings.speechLanguage)
@@ -738,7 +755,7 @@ class PhoneAIService : Service() {
                 Log.d(TAG, "Using AI-based speech service, language: ${settings.speechLanguage}")
                 speechService?.transcribe(audioData, settings.speechLanguage)
             }
-            
+
             val transcript = when (transcriptResult) {
                 is SpeechResult.Success -> {
                     Log.d(TAG, "Transcript: ${transcriptResult.text}")
@@ -747,7 +764,6 @@ class PhoneAIService : Service() {
                 is SpeechResult.Error -> {
                     Log.e(TAG, "Transcription error: ${transcriptResult.message}")
                     bluetoothManager?.sendMessage(Message.aiError(transcriptResult.message))
-                    // Check if error is API key related
                     if (transcriptResult.message.contains("API", ignoreCase = true) ||
                         transcriptResult.message.contains("key", ignoreCase = true) ||
                         transcriptResult.message.contains("401") ||
@@ -763,44 +779,44 @@ class PhoneAIService : Service() {
                     return
                 }
             }
-            
+
             // 3. Send user voice text to glasses and phone UI
             bluetoothManager?.sendMessage(Message(
                 type = MessageType.USER_TRANSCRIPT,
                 payload = transcript
             ))
-            
+
             ServiceBridge.emitConversation(Message(
                 type = MessageType.USER_TRANSCRIPT,
                 payload = transcript
             ))
-            
+
             // 3.1 Save user message to database for history
             saveUserMessage(transcript)
-            
+
             // 4. Notify thinking
             bluetoothManager?.sendMessage(Message.aiProcessing(getString(R.string.thinking)))
-            
+
             // 5. AI conversation (using main AI service)
             Log.d(TAG, "Getting AI response...")
             val rawAiResponse = aiService?.chat(transcript) ?: "Sorry, an error occurred while processing."
-            
+
             // Clean markdown formatting for better display on glasses
             val aiResponse = cleanMarkdown(rawAiResponse)
-            
+
             Log.d(TAG, "AI response: $aiResponse")
-            
+
             // 6. Send AI response to glasses and phone UI
             bluetoothManager?.sendMessage(Message.aiResponseText(aiResponse))
-            
+
             ServiceBridge.emitConversation(Message(
                 type = MessageType.AI_RESPONSE_TEXT,
                 payload = aiResponse
             ))
-            
+
             // 6.1 Save AI response to database for history
             saveAssistantMessage(aiResponse, settings.aiModelId)
-            
+
             // 6.2 Save glasses recording to database (with transcript and AI response)
             try {
                 recordingRepository?.saveGlassesRecording(
@@ -814,17 +830,130 @@ class PhoneAIService : Service() {
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to save glasses recording", e)
             }
-            
+
             // 7. TTS voice playback (optional)
             ttsService?.speak(aiResponse) { }
-            
+
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-            // Service is being stopped, don't treat this as an error
             Log.d(TAG, "Voice processing cancelled (service stopping)")
-            throw e  // Re-throw to properly propagate cancellation
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error processing voice data", e)
             bluetoothManager?.sendMessage(Message.aiError(getString(R.string.processing_failed, e.message ?: "")))
+        }
+    }
+
+    /**
+     * Process voice data via Private Server in a single request.
+     * Sends raw audio to VPS which handles STT + Claude + TTS, then returns
+     * both user transcript and AI response with audio.
+     */
+    private suspend fun processVoiceDataViaPrivateServer(
+        audioData: ByteArray,
+        settings: ApiSettings
+    ) {
+        val privateServer = aiService as PrivateServerService
+
+        // 1. Notify glasses: processing
+        bluetoothManager?.sendMessage(Message.aiProcessing(getString(R.string.recognizing_speech)))
+        ServiceBridge.emitConversation(Message(
+            type = MessageType.AI_PROCESSING,
+            payload = getString(R.string.recognizing_speech)
+        ))
+
+        // 2. Single request: audio -> VPS -> STT + Claude + TTS
+        Log.d(TAG, "Private Server: sending ${audioData.size} bytes for combined processing")
+        val result = privateServer.processVoiceAudio(audioData)
+
+        if (result == null) {
+            val errorMsg = "Server communication failed"
+            bluetoothManager?.sendMessage(Message.aiError(errorMsg))
+            ServiceBridge.emitConversation(Message(
+                type = MessageType.AI_ERROR,
+                payload = errorMsg
+            ))
+            return
+        }
+
+        // 3. Show user transcript
+        bluetoothManager?.sendMessage(Message(
+            type = MessageType.USER_TRANSCRIPT,
+            payload = result.userTranscript
+        ))
+        ServiceBridge.emitConversation(Message(
+            type = MessageType.USER_TRANSCRIPT,
+            payload = result.userTranscript
+        ))
+        saveUserMessage(result.userTranscript)
+
+        // 4. Show AI response
+        val aiResponse = cleanMarkdown(result.aiResponseText)
+        bluetoothManager?.sendMessage(Message.aiResponseText(aiResponse))
+        ServiceBridge.emitConversation(Message(
+            type = MessageType.AI_RESPONSE_TEXT,
+            payload = aiResponse
+        ))
+        saveAssistantMessage(aiResponse, settings.aiModelId)
+
+        // 5. Save recording
+        try {
+            recordingRepository?.saveGlassesRecording(
+                audioData = audioData,
+                transcript = result.userTranscript,
+                aiResponse = aiResponse,
+                providerId = settings.aiProvider.name,
+                modelId = settings.aiModelId
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to save glasses recording", e)
+        }
+
+        // 6. Play VPS audio response (server-generated TTS)
+        if (result.aiResponseAudio != null && result.aiResponseAudio.isNotEmpty()) {
+            Log.d(TAG, "Playing VPS audio response: ${result.aiResponseAudio.size} bytes")
+            playAudioResponse(result.aiResponseAudio)
+        } else {
+            // Fallback to local TTS if no audio from server
+            ttsService?.speak(aiResponse) { }
+        }
+
+        Log.d(TAG, "Private Server voice processing complete")
+    }
+
+    /**
+     * Play raw audio bytes (OGG format from VPS TTS) through the device speaker.
+     */
+    private fun playAudioResponse(audioData: ByteArray) {
+        try {
+            val tempFile = java.io.File.createTempFile("vps_tts_", ".ogg", cacheDir)
+            tempFile.writeBytes(audioData)
+
+            val mediaPlayer = android.media.MediaPlayer()
+            mediaPlayer.setDataSource(tempFile.absolutePath)
+            mediaPlayer.setOnCompletionListener {
+                it.release()
+                tempFile.delete()
+            }
+            mediaPlayer.setOnErrorListener { mp, _, _ ->
+                mp.release()
+                tempFile.delete()
+                Log.e(TAG, "MediaPlayer error playing VPS audio")
+                // Fallback to local TTS
+                serviceScope.launch {
+                    val text = (aiService as? PrivateServerService)?.lastAiResponseText ?: ""
+                    if (text.isNotBlank()) ttsService?.speak(text) { }
+                }
+                true
+            }
+            mediaPlayer.prepare()
+            mediaPlayer.start()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to play VPS audio", e)
+            // Fallback to local TTS
+            serviceScope.launch {
+                val text = (aiService as? PrivateServerService)?.lastAiResponseText ?: ""
+                if (text.isNotBlank()) ttsService?.speak(text) { }
+            }
         }
     }
     

--- a/phone-app/src/main/java/com/example/rokidphone/service/ai/AiServiceFactory.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/service/ai/AiServiceFactory.kt
@@ -149,6 +149,12 @@ object AiServiceFactory {
                 presencePenalty = settings.presencePenalty
             )
             
+            AiProvider.VPS -> VpsService(
+                baseUrl = settings.vpsBaseUrl.ifBlank { AiProvider.VPS.defaultBaseUrl },
+                authToken = settings.vpsAuthToken,
+                sessionId = "glasses-main"
+            )
+
             AiProvider.CUSTOM -> OpenAiCompatibleService(
                 apiKey = settings.customApiKey,
                 baseUrl = settings.getCurrentBaseUrl(),
@@ -184,7 +190,7 @@ object AiServiceFactory {
      */
     fun createTestService(settings: ApiSettings): OpenAiCompatibleService? {
         return when (settings.aiProvider) {
-            AiProvider.GEMINI, AiProvider.ANTHROPIC, AiProvider.BAIDU, AiProvider.GEMINI_LIVE -> null // Not OpenAI-compatible
+            AiProvider.GEMINI, AiProvider.ANTHROPIC, AiProvider.BAIDU, AiProvider.GEMINI_LIVE, AiProvider.VPS -> null // Not OpenAI-compatible
             
             AiProvider.OPENAI, AiProvider.DEEPSEEK, AiProvider.GROQ, 
             AiProvider.XAI, AiProvider.ALIBABA, AiProvider.ZHIPU, AiProvider.PERPLEXITY,

--- a/phone-app/src/main/java/com/example/rokidphone/service/ai/AiServiceFactory.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/service/ai/AiServiceFactory.kt
@@ -149,9 +149,9 @@ object AiServiceFactory {
                 presencePenalty = settings.presencePenalty
             )
             
-            AiProvider.VPS -> VpsService(
-                baseUrl = settings.vpsBaseUrl.ifBlank { AiProvider.VPS.defaultBaseUrl },
-                authToken = settings.vpsAuthToken,
+            AiProvider.PRIVATE_SERVER -> PrivateServerService(
+                baseUrl = settings.privateServerUrl,
+                authToken = settings.privateServerToken,
                 sessionId = "glasses-main"
             )
 
@@ -190,7 +190,7 @@ object AiServiceFactory {
      */
     fun createTestService(settings: ApiSettings): OpenAiCompatibleService? {
         return when (settings.aiProvider) {
-            AiProvider.GEMINI, AiProvider.ANTHROPIC, AiProvider.BAIDU, AiProvider.GEMINI_LIVE, AiProvider.VPS -> null // Not OpenAI-compatible
+            AiProvider.GEMINI, AiProvider.ANTHROPIC, AiProvider.BAIDU, AiProvider.GEMINI_LIVE, AiProvider.PRIVATE_SERVER -> null // Not OpenAI-compatible
             
             AiProvider.OPENAI, AiProvider.DEEPSEEK, AiProvider.GROQ, 
             AiProvider.XAI, AiProvider.ALIBABA, AiProvider.ZHIPU, AiProvider.PERPLEXITY,

--- a/phone-app/src/main/java/com/example/rokidphone/service/ai/PrivateServerService.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/service/ai/PrivateServerService.kt
@@ -10,22 +10,49 @@ import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.ByteArrayOutputStream
 import java.net.URLDecoder
 import java.util.concurrent.TimeUnit
 
 /**
+ * Result of a combined voice processing request (audio in -> AI response out).
+ */
+data class VoiceResult(
+    val userTranscript: String,
+    val aiResponseText: String,
+    val aiResponseAudio: ByteArray?
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as VoiceResult
+        return userTranscript == other.userTranscript &&
+                aiResponseText == other.aiResponseText &&
+                aiResponseAudio?.contentEquals(other.aiResponseAudio ?: byteArrayOf()) == true
+    }
+
+    override fun hashCode(): Int {
+        var result = userTranscript.hashCode()
+        result = 31 * result + aiResponseText.hashCode()
+        result = 31 * result + (aiResponseAudio?.contentHashCode() ?: 0)
+        return result
+    }
+}
+
+/**
  * Private Server AI Service
  *
- * Sends photos and text to a self-hosted server for AI analysis.
- * The server must implement two endpoints:
+ * Sends audio, photos, text, and video to a self-hosted server for AI processing.
+ * The server implements these endpoints:
  *
- * POST {baseUrl}/voice/photo  (multipart: image + prompt + session_id)
- *   → Response: audio body + X-Transcript header with text
+ * POST {baseUrl}/voice        (JSON: text + session_id)  -> text chat
+ * POST {baseUrl}/voice        (multipart: audio + session_id) -> STT + AI + TTS
+ * POST {baseUrl}/voice/photo  (multipart: image + prompt + session_id) -> photo analysis
+ * POST {baseUrl}/voice/video  (multipart: video + prompt + session_id) -> video analysis
  *
- * POST {baseUrl}/voice        (JSON: text + session_id)
- *   → Response: audio body + X-Transcript header with text
+ * All endpoints return: audio body + X-Transcript header (AI response text).
+ * Multipart /voice also returns X-User-Transcript header (user's speech).
  *
- * Compatible with any server implementing this protocol.
  * Base URL and auth token are configured in app settings.
  */
 class PrivateServerService(
@@ -50,11 +77,106 @@ class PrivateServerService(
     var lastAudioResponse: ByteArray? = null
         private set
 
+    // Store last AI response text (from combined voice flow)
+    var lastAiResponseText: String? = null
+        private set
+
+    /**
+     * Transcribe audio by sending it to the VPS.
+     * The VPS does STT + Claude + TTS in one call.
+     * This method returns only the user's speech transcript.
+     * The AI response and audio are cached in [lastAiResponseText] and [lastAudioResponse].
+     */
     override suspend fun transcribe(
         pcmAudioData: ByteArray,
         languageCode: String
-    ): SpeechResult {
-        return SpeechResult.Error("Private server does not support standalone speech-to-text")
+    ): SpeechResult = withContext(Dispatchers.IO) {
+        try {
+            val wavData = pcmToWav(pcmAudioData)
+            Log.d(TAG, "Transcribe: sending ${wavData.size} bytes to VPS")
+
+            val result = processVoiceAudio(wavData, "audio/wav")
+            if (result != null) {
+                SpeechResult.Success(result.userTranscript)
+            } else {
+                SpeechResult.Error("Failed to transcribe audio via server")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Transcribe error", e)
+            SpeechResult.Error("Transcription error: ${e.message}")
+        }
+    }
+
+    /**
+     * Combined voice processing: send raw audio, get back user transcript +
+     * AI response text + AI response audio in a single request.
+     *
+     * @param audioData Encoded audio (WAV, OGG, etc.)
+     * @param mimeType MIME type of the audio
+     * @return VoiceResult or null on failure
+     */
+    suspend fun processVoiceAudio(
+        audioData: ByteArray,
+        mimeType: String = "audio/wav"
+    ): VoiceResult? = withContext(Dispatchers.IO) {
+        try {
+            Log.d(TAG, "processVoiceAudio: ${audioData.size} bytes ($mimeType)")
+
+            val ext = when {
+                mimeType.contains("ogg") -> "ogg"
+                mimeType.contains("mp4") || mimeType.contains("m4a") -> "m4a"
+                else -> "wav"
+            }
+
+            val requestBody = MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart(
+                    "audio", "recording.$ext",
+                    audioData.toRequestBody(mimeType.toMediaType())
+                )
+                .addFormDataPart("session_id", sessionId)
+                .addFormDataPart("source", "glasses")
+                .build()
+
+            val requestBuilder = Request.Builder()
+                .url("${baseUrl.trimEnd('/')}/voice")
+                .post(requestBody)
+
+            requestBuilder.addVoiceAuth()
+
+            val response = client.newCall(requestBuilder.build()).execute()
+
+            if (!response.isSuccessful) {
+                val errorBody = response.body?.string() ?: "Unknown error"
+                Log.e(TAG, "Voice audio failed: ${response.code} - $errorBody")
+                return@withContext null
+            }
+
+            val aiTranscript = response.header("X-Transcript")?.let {
+                URLDecoder.decode(it, "UTF-8")
+            } ?: ""
+
+            val userTranscript = response.header("X-User-Transcript")?.let {
+                URLDecoder.decode(it, "UTF-8")
+            } ?: ""
+
+            val audioResponse = response.body?.bytes()
+
+            // Cache for playback
+            lastAudioResponse = audioResponse
+            lastAiResponseText = aiTranscript
+
+            Log.d(TAG, "Voice audio done: user='${userTranscript.take(80)}' ai='${aiTranscript.take(80)}'")
+
+            VoiceResult(
+                userTranscript = userTranscript.ifBlank { "[speech not recognized]" },
+                aiResponseText = aiTranscript.ifBlank { "Response received." },
+                aiResponseAudio = audioResponse
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "processVoiceAudio error", e)
+            null
+        }
     }
 
     override suspend fun chat(userMessage: String): String = withContext(Dispatchers.IO) {
@@ -69,9 +191,7 @@ class PrivateServerService(
                 .url("${baseUrl.trimEnd('/')}/voice")
                 .post(jsonBody.toRequestBody("application/json".toMediaType()))
 
-            if (authToken.isNotBlank()) {
-                requestBuilder.addHeader("Authorization", "Bearer $authToken")
-            }
+            requestBuilder.addVoiceAuth()
 
             val response = client.newCall(requestBuilder.build()).execute()
 
@@ -86,6 +206,7 @@ class PrivateServerService(
             } ?: ""
 
             lastAudioResponse = response.body?.bytes()
+            lastAiResponseText = transcript
 
             Log.d(TAG, "Chat response: ${transcript.take(100)}")
             transcript.ifBlank { "Response received but no transcript available." }
@@ -116,9 +237,7 @@ class PrivateServerService(
                 .url("${baseUrl.trimEnd('/')}/voice/photo")
                 .post(requestBody)
 
-            if (authToken.isNotBlank()) {
-                requestBuilder.addHeader("Authorization", "Bearer $authToken")
-            }
+            requestBuilder.addBearerAuth()
 
             val response = client.newCall(requestBuilder.build()).execute()
 
@@ -133,6 +252,7 @@ class PrivateServerService(
             } ?: ""
 
             lastAudioResponse = response.body?.bytes()
+            lastAiResponseText = transcript
 
             val elapsed = response.header("X-Duration-Ms") ?: "?"
             Log.d(TAG, "Photo analysis done in ${elapsed}ms: ${transcript.take(100)}")
@@ -144,11 +264,132 @@ class PrivateServerService(
         }
     }
 
+    /**
+     * Analyze a video clip with AI.
+     *
+     * @param videoData Video file bytes (MP4, etc.)
+     * @param prompt User prompt describing what to analyze
+     * @return AI response text
+     */
+    suspend fun analyzeVideo(
+        videoData: ByteArray,
+        prompt: String = "Describe what you see in this video"
+    ): String = withContext(Dispatchers.IO) {
+        try {
+            Log.d(TAG, "Video analysis: ${videoData.size} bytes, prompt: ${prompt.take(100)}")
+
+            val requestBody = MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart(
+                    "video", "recording.mp4",
+                    videoData.toRequestBody("video/mp4".toMediaType())
+                )
+                .addFormDataPart("prompt", prompt)
+                .addFormDataPart("session_id", sessionId)
+                .build()
+
+            val requestBuilder = Request.Builder()
+                .url("${baseUrl.trimEnd('/')}/voice/video")
+                .post(requestBody)
+
+            requestBuilder.addBearerAuth()
+
+            val response = client.newCall(requestBuilder.build()).execute()
+
+            if (!response.isSuccessful) {
+                val errorBody = response.body?.string() ?: "Unknown error"
+                Log.e(TAG, "Video analysis failed: ${response.code} - $errorBody")
+                return@withContext "Error analysing video: ${response.code}"
+            }
+
+            val transcript = response.header("X-Transcript")?.let {
+                URLDecoder.decode(it, "UTF-8")
+            } ?: ""
+
+            lastAudioResponse = response.body?.bytes()
+            lastAiResponseText = transcript
+
+            val elapsed = response.header("X-Duration-Ms") ?: "?"
+            Log.d(TAG, "Video analysis done in ${elapsed}ms: ${transcript.take(100)}")
+
+            transcript.ifBlank { "Video received but no analysis available." }
+        } catch (e: Exception) {
+            Log.e(TAG, "Video analysis error", e)
+            "Error analysing video: ${e.message}"
+        }
+    }
+
     override fun clearHistory() {
         lastAudioResponse = null
+        lastAiResponseText = null
+    }
+
+    /**
+     * Add auth header appropriate for the endpoint.
+     * /voice uses X-Auth-Token; /voice/photo and /voice/video use Authorization: Bearer.
+     */
+    private fun Request.Builder.addVoiceAuth(): Request.Builder {
+        if (authToken.isNotBlank()) {
+            addHeader("X-Auth-Token", authToken)
+        }
+        return this
+    }
+
+    private fun Request.Builder.addBearerAuth(): Request.Builder {
+        if (authToken.isNotBlank()) {
+            addHeader("Authorization", "Bearer $authToken")
+        }
+        return this
     }
 
     private fun escapeJson(value: String): String {
         return "\"${value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")}\""
+    }
+
+    /**
+     * Convert PCM audio data to WAV format for server upload.
+     */
+    private fun pcmToWav(
+        pcmData: ByteArray,
+        sampleRate: Int = 16000,
+        channels: Int = 1,
+        bitsPerSample: Int = 16
+    ): ByteArray {
+        val byteRate = sampleRate * channels * bitsPerSample / 8
+        val blockAlign = channels * bitsPerSample / 8
+        val dataSize = pcmData.size
+        val totalSize = 36 + dataSize
+
+        val output = ByteArrayOutputStream()
+
+        // RIFF header
+        output.write("RIFF".toByteArray())
+        output.write(intToBytes(totalSize, 4))
+        output.write("WAVE".toByteArray())
+
+        // fmt chunk
+        output.write("fmt ".toByteArray())
+        output.write(intToBytes(16, 4))
+        output.write(intToBytes(1, 2))       // PCM
+        output.write(intToBytes(channels, 2))
+        output.write(intToBytes(sampleRate, 4))
+        output.write(intToBytes(byteRate, 4))
+        output.write(intToBytes(blockAlign, 2))
+        output.write(intToBytes(bitsPerSample, 2))
+
+        // data chunk
+        output.write("data".toByteArray())
+        output.write(intToBytes(dataSize, 4))
+        output.write(pcmData)
+
+        return output.toByteArray()
+    }
+
+    private fun intToBytes(value: Int, numBytes: Int): ByteArray {
+        val bytes = ByteArray(numBytes)
+        for (i in 0 until numBytes) {
+            bytes[i] = (value shr (8 * i) and 0xFF).toByte()
+        }
+        return bytes
     }
 }

--- a/phone-app/src/main/java/com/example/rokidphone/service/ai/PrivateServerService.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/service/ai/PrivateServerService.kt
@@ -14,28 +14,31 @@ import java.net.URLDecoder
 import java.util.concurrent.TimeUnit
 
 /**
- * VPS AI Service
+ * Private Server AI Service
  *
- * Sends photos and text to a personal VPS running Claude Code,
- * which analyses images with Claude Vision and returns TTS audio + text.
+ * Sends photos and text to a self-hosted server for AI analysis.
+ * The server must implement two endpoints:
  *
- * Endpoint: POST {baseUrl}/voice/photo  (multipart: image + prompt + session_id)
- * Response: audio/mpeg body, X-Transcript header with text response
+ * POST {baseUrl}/voice/photo  (multipart: image + prompt + session_id)
+ *   → Response: audio body + X-Transcript header with text
  *
- * Endpoint: POST {baseUrl}/voice        (JSON: text + session_id)
- * Response: audio/ogg body, X-Transcript header with text response
+ * POST {baseUrl}/voice        (JSON: text + session_id)
+ *   → Response: audio body + X-Transcript header with text
+ *
+ * Compatible with any server implementing this protocol.
+ * Base URL and auth token are configured in app settings.
  */
-class VpsService(
+class PrivateServerService(
     private val baseUrl: String,
     private val authToken: String = "",
     private val sessionId: String = "glasses-main"
 ) : AiServiceProvider {
 
     companion object {
-        private const val TAG = "VpsService"
+        private const val TAG = "PrivateServerService"
     }
 
-    override val provider: AiProvider = AiProvider.VPS
+    override val provider: AiProvider = AiProvider.PRIVATE_SERVER
 
     private val client: OkHttpClient = OkHttpClient.Builder()
         .connectTimeout(30, TimeUnit.SECONDS)
@@ -51,10 +54,7 @@ class VpsService(
         pcmAudioData: ByteArray,
         languageCode: String
     ): SpeechResult {
-        // VPS doesn't do standalone STT — audio goes through /voice/audio
-        // which transcribes + processes + returns TTS all at once.
-        // For now, return an error suggesting to use a different STT provider.
-        return SpeechResult.Error("VPS does not support standalone speech-to-text")
+        return SpeechResult.Error("Private server does not support standalone speech-to-text")
     }
 
     override suspend fun chat(userMessage: String): String = withContext(Dispatchers.IO) {
@@ -81,19 +81,17 @@ class VpsService(
                 return@withContext "Error: ${response.code} - $errorBody"
             }
 
-            // Extract transcript from header
             val transcript = response.header("X-Transcript")?.let {
                 URLDecoder.decode(it, "UTF-8")
             } ?: ""
 
-            // Store audio for playback
             lastAudioResponse = response.body?.bytes()
 
             Log.d(TAG, "Chat response: ${transcript.take(100)}")
             transcript.ifBlank { "Response received but no transcript available." }
         } catch (e: Exception) {
             Log.e(TAG, "Chat error", e)
-            "Error communicating with VPS: ${e.message}"
+            "Error communicating with server: ${e.message}"
         }
     }
 
@@ -130,12 +128,10 @@ class VpsService(
                 return@withContext "Error analysing photo: ${response.code}"
             }
 
-            // Extract transcript from header
             val transcript = response.header("X-Transcript")?.let {
                 URLDecoder.decode(it, "UTF-8")
             } ?: ""
 
-            // Store audio for playback
             lastAudioResponse = response.body?.bytes()
 
             val elapsed = response.header("X-Duration-Ms") ?: "?"

--- a/phone-app/src/main/java/com/example/rokidphone/service/ai/VpsService.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/service/ai/VpsService.kt
@@ -1,0 +1,158 @@
+package com.example.rokidphone.service.ai
+
+import android.util.Log
+import com.example.rokidphone.data.AiProvider
+import com.example.rokidphone.service.SpeechResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.net.URLDecoder
+import java.util.concurrent.TimeUnit
+
+/**
+ * VPS AI Service
+ *
+ * Sends photos and text to a personal VPS running Claude Code,
+ * which analyses images with Claude Vision and returns TTS audio + text.
+ *
+ * Endpoint: POST {baseUrl}/voice/photo  (multipart: image + prompt + session_id)
+ * Response: audio/mpeg body, X-Transcript header with text response
+ *
+ * Endpoint: POST {baseUrl}/voice        (JSON: text + session_id)
+ * Response: audio/ogg body, X-Transcript header with text response
+ */
+class VpsService(
+    private val baseUrl: String,
+    private val authToken: String = "",
+    private val sessionId: String = "glasses-main"
+) : AiServiceProvider {
+
+    companion object {
+        private const val TAG = "VpsService"
+    }
+
+    override val provider: AiProvider = AiProvider.VPS
+
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(90, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    // Store last audio response for playback
+    var lastAudioResponse: ByteArray? = null
+        private set
+
+    override suspend fun transcribe(
+        pcmAudioData: ByteArray,
+        languageCode: String
+    ): SpeechResult {
+        // VPS doesn't do standalone STT — audio goes through /voice/audio
+        // which transcribes + processes + returns TTS all at once.
+        // For now, return an error suggesting to use a different STT provider.
+        return SpeechResult.Error("VPS does not support standalone speech-to-text")
+    }
+
+    override suspend fun chat(userMessage: String): String = withContext(Dispatchers.IO) {
+        try {
+            Log.d(TAG, "Chat request: ${userMessage.take(100)}")
+
+            val jsonBody = """
+                {"text": ${escapeJson(userMessage)}, "session_id": ${escapeJson(sessionId)}}
+            """.trimIndent()
+
+            val requestBuilder = Request.Builder()
+                .url("${baseUrl.trimEnd('/')}/voice")
+                .post(jsonBody.toRequestBody("application/json".toMediaType()))
+
+            if (authToken.isNotBlank()) {
+                requestBuilder.addHeader("Authorization", "Bearer $authToken")
+            }
+
+            val response = client.newCall(requestBuilder.build()).execute()
+
+            if (!response.isSuccessful) {
+                val errorBody = response.body?.string() ?: "Unknown error"
+                Log.e(TAG, "Chat failed: ${response.code} - $errorBody")
+                return@withContext "Error: ${response.code} - $errorBody"
+            }
+
+            // Extract transcript from header
+            val transcript = response.header("X-Transcript")?.let {
+                URLDecoder.decode(it, "UTF-8")
+            } ?: ""
+
+            // Store audio for playback
+            lastAudioResponse = response.body?.bytes()
+
+            Log.d(TAG, "Chat response: ${transcript.take(100)}")
+            transcript.ifBlank { "Response received but no transcript available." }
+        } catch (e: Exception) {
+            Log.e(TAG, "Chat error", e)
+            "Error communicating with VPS: ${e.message}"
+        }
+    }
+
+    override suspend fun analyzeImage(
+        imageData: ByteArray,
+        prompt: String
+    ): String = withContext(Dispatchers.IO) {
+        try {
+            Log.d(TAG, "Photo analysis: ${imageData.size} bytes, prompt: ${prompt.take(100)}")
+
+            val requestBody = MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart(
+                    "image", "photo.jpg",
+                    imageData.toRequestBody("image/jpeg".toMediaType())
+                )
+                .addFormDataPart("prompt", prompt)
+                .addFormDataPart("session_id", sessionId)
+                .build()
+
+            val requestBuilder = Request.Builder()
+                .url("${baseUrl.trimEnd('/')}/voice/photo")
+                .post(requestBody)
+
+            if (authToken.isNotBlank()) {
+                requestBuilder.addHeader("Authorization", "Bearer $authToken")
+            }
+
+            val response = client.newCall(requestBuilder.build()).execute()
+
+            if (!response.isSuccessful) {
+                val errorBody = response.body?.string() ?: "Unknown error"
+                Log.e(TAG, "Photo analysis failed: ${response.code} - $errorBody")
+                return@withContext "Error analysing photo: ${response.code}"
+            }
+
+            // Extract transcript from header
+            val transcript = response.header("X-Transcript")?.let {
+                URLDecoder.decode(it, "UTF-8")
+            } ?: ""
+
+            // Store audio for playback
+            lastAudioResponse = response.body?.bytes()
+
+            val elapsed = response.header("X-Duration-Ms") ?: "?"
+            Log.d(TAG, "Photo analysis done in ${elapsed}ms: ${transcript.take(100)}")
+
+            transcript.ifBlank { "Photo received but no analysis available." }
+        } catch (e: Exception) {
+            Log.e(TAG, "Photo analysis error", e)
+            "Error analysing photo: ${e.message}"
+        }
+    }
+
+    override fun clearHistory() {
+        lastAudioResponse = null
+    }
+
+    private fun escapeJson(value: String): String {
+        return "\"${value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")}\""
+    }
+}

--- a/phone-app/src/main/res/values/strings.xml
+++ b/phone-app/src/main/res/values/strings.xml
@@ -200,6 +200,7 @@
     <string name="provider_baidu">Baidu Ernie</string>
     <string name="provider_perplexity">Perplexity</string>
     <string name="provider_moonshot">Moonshot (Kimi)</string>
+    <string name="provider_vps">Personal VPS</string>
     <string name="provider_custom">Custom / Self-Hosted</string>
     <string name="provider_gemini_live">Gemini Live</string>
     

--- a/phone-app/src/main/res/values/strings.xml
+++ b/phone-app/src/main/res/values/strings.xml
@@ -200,7 +200,7 @@
     <string name="provider_baidu">Baidu Ernie</string>
     <string name="provider_perplexity">Perplexity</string>
     <string name="provider_moonshot">Moonshot (Kimi)</string>
-    <string name="provider_vps">Personal VPS</string>
+    <string name="provider_private_server">Private Server</string>
     <string name="provider_custom">Custom / Self-Hosted</string>
     <string name="provider_gemini_live">Gemini Live</string>
     


### PR DESCRIPTION
## Summary
- **Single-request voice flow**: When Private Server is selected, audio from glasses goes directly to VPS in one call (STT + Claude + TTS), eliminating the need for a separate STT API key
- **VPS audio playback**: Plays server-generated TTS audio instead of regenerating locally
- **Video analysis**: New `analyzeVideo()` method for `/voice/video` endpoint
- **Auth fix**: Correct headers per endpoint (X-Auth-Token for /voice, Bearer for /voice/photo and /voice/video)

## Test plan
- [ ] Select Private Server provider, speak through glasses — verify user transcript + AI response display
- [ ] Take photo through glasses — verify photo analysis + VPS TTS playback
- [ ] Build APK and test on device

Generated with [Claude Code](https://claude.com/claude-code)