### PR TITLE
fix(custom): manual vision override for custom endpoints (Closes #9)

### DIFF
--- a/phone-app/src/main/java/com/example/rokidphone/ai/catalog/ModelCapabilityResolver.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ai/catalog/ModelCapabilityResolver.kt
@@ -7,12 +7,19 @@ import com.example.rokidphone.data.AiProvider
  *
  * Priority:
  *  1. live Models API metadata (passed in by the catalog parser),
- *  2. verified fallback capability map ([FallbackModelCatalog]),
- *  3. conservative provider default — text in/out, streaming by protocol,
- *     image input only where the provider ships vision-capable chat models,
- *  4. manual overrides (Custom provider only).
+ *  2. manual overrides (user-declared; Custom provider only — the user knows
+ *     their local model better than any static list),
+ *  3. verified fallback capability map ([FallbackModelCatalog]),
+ *  4. conservative provider default — text in/out, streaming by protocol,
+ *     image input only where the provider ships vision-capable chat models.
  */
 object ModelCapabilityResolver {
+
+    /** Manual override key: model accepts image input. */
+    const val OVERRIDE_VISION = "vision"
+
+    /** Manual override key: model accepts audio input. */
+    const val OVERRIDE_AUDIO_INPUT = "audio_input"
 
     /** Providers whose mainstream chat models accept image input. */
     private val providerDefaultVision: Set<AiProvider> = setOf(
@@ -30,9 +37,23 @@ object ModelCapabilityResolver {
         manualOverrides: ModelCapabilities? = null
     ): ModelCapabilities {
         liveCapabilities?.let { return it }
-        FallbackModelCatalog.capabilityFor(provider, modelId)?.let { return it }
         manualOverrides?.let { return it }
+        FallbackModelCatalog.capabilityFor(provider, modelId)?.let { return it }
         return providerDefault(provider)
+    }
+
+    /**
+     * Build manual overrides from the user's override keys (persisted in
+     * settings). Unknown keys are ignored. Returns null when there is nothing
+     * to override so callers can keep the normal resolution path.
+     */
+    fun overridesFromKeys(provider: AiProvider, keys: Set<String>): ModelCapabilities? {
+        if (keys.isEmpty()) return null
+        val base = providerDefault(provider)
+        return base.copy(
+            imageInput = base.imageInput || OVERRIDE_VISION in keys,
+            audioInput = base.audioInput || OVERRIDE_AUDIO_INPUT in keys
+        )
     }
 
     /** Conservative default when nothing is known about the model. */

--- a/phone-app/src/main/java/com/example/rokidphone/service/ai/AiServiceFactory.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/service/ai/AiServiceFactory.kt
@@ -158,7 +158,9 @@ object AiServiceFactory {
                 topP = settings.topP,
                 frequencyPenalty = settings.frequencyPenalty,
                 presencePenalty = settings.presencePenalty,
-                useResponsesApi = settings.customProtocol == "responses"
+                useResponsesApi = settings.customProtocol == "responses",
+                capabilityOverrides = com.example.rokidphone.ai.catalog.ModelCapabilityResolver
+                    .overridesFromKeys(AiProvider.CUSTOM, settings.customCapabilityOverrides)
             )
 
             else -> OpenAiCompatibleService(
@@ -268,7 +270,9 @@ object AiServiceFactory {
                 modelId = settings.customModelName.ifBlank { settings.aiModelId },
                 systemPrompt = "",
                 providerType = AiProvider.CUSTOM,
-                useResponsesApi = settings.customProtocol == "responses"
+                useResponsesApi = settings.customProtocol == "responses",
+                capabilityOverrides = com.example.rokidphone.ai.catalog.ModelCapabilityResolver
+                    .overridesFromKeys(AiProvider.CUSTOM, settings.customCapabilityOverrides)
             )
         }
     }

--- a/phone-app/src/main/java/com/example/rokidphone/service/ai/OpenAiCompatibleService.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/service/ai/OpenAiCompatibleService.kt
@@ -44,7 +44,13 @@ open class OpenAiCompatibleService(
     /** "low" | "medium" | "high" — OpenAI GPT-5.2+ only. */
     val verbosity: String? = null,
     /** Use the OpenAI Responses API instead of Chat Completions (falls back automatically). */
-    private val useResponsesApi: Boolean = false
+    private val useResponsesApi: Boolean = false,
+    /**
+     * User-declared capability overrides (Custom endpoints only). When set,
+     * these win over catalog/provider-default resolution — e.g. enabling
+     * image input for a local LM Studio model that supports vision.
+     */
+    private val capabilityOverrides: com.example.rokidphone.ai.catalog.ModelCapabilities? = null
 ) : BaseAiService(apiKey, modelId, systemPrompt, temperature, maxTokens, topP, frequencyPenalty, presencePenalty), AiServiceProvider {
 
     companion object {
@@ -60,12 +66,16 @@ open class OpenAiCompatibleService(
 
     override val provider = providerType
 
+    /** Effective capabilities: user overrides (Custom) → catalog → provider default. */
+    private val effectiveCapabilities: com.example.rokidphone.ai.catalog.ModelCapabilities
+        get() = capabilityOverrides ?: ModelCapabilityResolver.resolve(providerType, modelId)
+
     /** Effective request policy for the current provider+model. */
     private val policy: ProviderRequestPolicy
         get() = ProviderRequestPolicies.resolve(
             providerType,
             modelId,
-            ModelCapabilityResolver.resolve(providerType, modelId),
+            effectiveCapabilities,
             reasoningEffort
         )
 
@@ -649,8 +659,7 @@ open class OpenAiCompatibleService(
 
     override suspend fun analyzeImage(imageData: ByteArray, prompt: String): String {
         return withContext(Dispatchers.IO) {
-            val capabilities = ModelCapabilityResolver.resolve(providerType, modelId)
-            if (!capabilities.imageInput || policy.imageContentFormat == ImageContentFormat.NONE) {
+            if (!effectiveCapabilities.imageInput || policy.imageContentFormat == ImageContentFormat.NONE) {
                 return@withContext "This provider does not support image analysis."
             }
 

--- a/phone-app/src/main/java/com/example/rokidphone/ui/SettingsScreen.kt
+++ b/phone-app/src/main/java/com/example/rokidphone/ui/SettingsScreen.kt
@@ -170,7 +170,9 @@ fun SettingsScreen(
                         protocol = settings.customProtocol,
                         onProtocolChange = { onSettingsChange(settings.copy(customProtocol = it)) },
                         modelsPath = settings.customModelsPath,
-                        onModelsPathChange = { onSettingsChange(settings.copy(customModelsPath = it)) }
+                        onModelsPathChange = { onSettingsChange(settings.copy(customModelsPath = it)) },
+                        capabilityOverrides = settings.customCapabilityOverrides,
+                        onCapabilityOverridesChange = { onSettingsChange(settings.copy(customCapabilityOverrides = it)) }
                     )
                 }
             }
@@ -1681,7 +1683,9 @@ fun CustomProviderSection(
     protocol: String = "chat_completions",
     onProtocolChange: (String) -> Unit = {},
     modelsPath: String = "models",
-    onModelsPathChange: (String) -> Unit = {}
+    onModelsPathChange: (String) -> Unit = {},
+    capabilityOverrides: Set<String> = emptySet(),
+    onCapabilityOverridesChange: (Set<String>) -> Unit = {}
 ) {
     var isValidUrl by remember(baseUrl) { 
         mutableStateOf(isHttpUrl(baseUrl))
@@ -1769,6 +1773,22 @@ fun CustomProviderSection(
                 placeholder = { Text("models") },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Manual capability override: the catalog cannot know what a
+            // local endpoint's model supports, so the user declares it.
+            SettingsRowWithSwitch(
+                title = stringResource(R.string.custom_supports_vision),
+                subtitle = stringResource(R.string.custom_supports_vision_subtitle),
+                checked = com.example.rokidphone.ai.catalog.ModelCapabilityResolver.OVERRIDE_VISION in capabilityOverrides,
+                onCheckedChange = { checked ->
+                    val key = com.example.rokidphone.ai.catalog.ModelCapabilityResolver.OVERRIDE_VISION
+                    onCapabilityOverridesChange(
+                        if (checked) capabilityOverrides + key else capabilityOverrides - key
+                    )
+                }
             )
 
             Spacer(modifier = Modifier.height(12.dp))

--- a/phone-app/src/main/res/values-ar/strings.xml
+++ b/phone-app/src/main/res/values-ar/strings.xml
@@ -144,6 +144,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">مسار نقطة نهاية Models</string>
+    <string name="custom_supports_vision">النموذج يدعم إدخال الصور (الرؤية)</string>
+    <string name="custom_supports_vision_subtitle">فعّل إذا كان بإمكان هذا النموذج تحليل الصور (مثل Gemma 4 وLLaVA وMiniCPM-V). مطلوب لتحليل الصور على نقاط النهاية المخصصة.</string>
     <string name="secure_storage_unavailable">تعذر تهيئة التخزين المشفر. لن يتم حفظ مفاتيح API على هذا الجهاز.</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values-es/strings.xml
+++ b/phone-app/src/main/res/values-es/strings.xml
@@ -143,6 +143,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Ruta del endpoint de modelos</string>
+    <string name="custom_supports_vision">El modelo admite entrada de imágenes (visión)</string>
+    <string name="custom_supports_vision_subtitle">Actívelo si este modelo puede analizar imágenes (p. ej., Gemma 4, LLaVA, MiniCPM-V). Necesario para el análisis de fotos en endpoints personalizados.</string>
     <string name="secure_storage_unavailable">No se pudo inicializar el almacenamiento cifrado. Las claves API no se guardarán en este dispositivo.</string>
     <!-- API Key Validation -->
     <string name="api_key_required">Se requiere clave API</string>

--- a/phone-app/src/main/res/values-fr/strings.xml
+++ b/phone-app/src/main/res/values-fr/strings.xml
@@ -144,6 +144,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Chemin de l\'endpoint des modèles</string>
+    <string name="custom_supports_vision">Le modèle prend en charge l\'entrée d\'images (vision)</string>
+    <string name="custom_supports_vision_subtitle">Activez si ce modèle peut analyser des images (p. ex. Gemma 4, LLaVA, MiniCPM-V). Requis pour l\'analyse de photos sur les endpoints personnalisés.</string>
     <string name="secure_storage_unavailable">Impossible d\'initialiser le stockage chiffré. Les clés API ne seront pas enregistrées sur cet appareil.</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values-it/strings.xml
+++ b/phone-app/src/main/res/values-it/strings.xml
@@ -144,6 +144,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Percorso endpoint modelli</string>
+    <string name="custom_supports_vision">Il modello supporta l\'input di immagini (vision)</string>
+    <string name="custom_supports_vision_subtitle">Abilita se questo modello può analizzare immagini (es. Gemma 4, LLaVA, MiniCPM-V). Necessario per l\'analisi delle foto su endpoint personalizzati.</string>
     <string name="secure_storage_unavailable">Impossibile inizializzare l\'archivio crittografato. Le chiavi API non verranno salvate su questo dispositivo.</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values-ja/strings.xml
+++ b/phone-app/src/main/res/values-ja/strings.xml
@@ -144,6 +144,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Models エンドポイントパス</string>
+    <string name="custom_supports_vision">モデルは画像入力(ビジョン)に対応</string>
+    <string name="custom_supports_vision_subtitle">このモデルが画像を解析できる場合(Gemma 4、LLaVA、MiniCPM-V など)に有効化してください。カスタムエンドポイントでの写真解析に必要です。</string>
     <string name="secure_storage_unavailable">暗号化ストレージを初期化できませんでした。API キーはこのデバイスに保存されません。</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values-ko/strings.xml
+++ b/phone-app/src/main/res/values-ko/strings.xml
@@ -144,6 +144,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Models 엔드포인트 경로</string>
+    <string name="custom_supports_vision">모델이 이미지 입력(비전) 지원</string>
+    <string name="custom_supports_vision_subtitle">이 모델이 이미지를 분석할 수 있는 경우(Gemma 4, LLaVA, MiniCPM-V 등) 활성화하세요. 사용자 지정 엔드포인트의 사진 분석에 필요합니다.</string>
     <string name="secure_storage_unavailable">암호화된 저장소를 초기화할 수 없습니다. API 키는 이 기기에 저장되지 않습니다.</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values-ru/strings.xml
+++ b/phone-app/src/main/res/values-ru/strings.xml
@@ -144,6 +144,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Путь эндпоинта моделей</string>
+    <string name="custom_supports_vision">Модель поддерживает ввод изображений (зрение)</string>
+    <string name="custom_supports_vision_subtitle">Включите, если эта модель может анализировать изображения (например, Gemma 4, LLaVA, MiniCPM-V). Требуется для анализа фото на пользовательских эндпоинтах.</string>
     <string name="secure_storage_unavailable">Не удалось инициализировать зашифрованное хранилище. Ключи API не будут сохранены на этом устройстве.</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values-th/strings.xml
+++ b/phone-app/src/main/res/values-th/strings.xml
@@ -275,6 +275,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">เส้นทางเอนด์พอยต์ Models</string>
+    <string name="custom_supports_vision">โมเดลรองรับอินพุตรูปภาพ (วิชัน)</string>
+    <string name="custom_supports_vision_subtitle">เปิดใช้หากโมเดลนี้สามารถวิเคราะห์รูปภาพได้ (เช่น Gemma 4, LLaVA, MiniCPM-V) จำเป็นสำหรับการวิเคราะห์ภาพถ่ายบนเอนด์พอยต์ที่กำหนดเอง</string>
     <string name="secure_storage_unavailable">ไม่สามารถเริ่มที่เก็บข้อมูลแบบเข้ารหัสได้ คีย์ API จะไม่ถูกบันทึกบนอุปกรณ์นี้</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values-uk/strings.xml
+++ b/phone-app/src/main/res/values-uk/strings.xml
@@ -144,6 +144,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Шлях endpoint моделей</string>
+    <string name="custom_supports_vision">Модель підтримує введення зображень (зір)</string>
+    <string name="custom_supports_vision_subtitle">Увімкніть, якщо ця модель може аналізувати зображення (наприклад, Gemma 4, LLaVA, MiniCPM-V). Потрібно для аналізу фото на власних ендпоінтах.</string>
     <string name="secure_storage_unavailable">Не вдалося ініціалізувати зашифроване сховище. Ключі API не будуть збережені на цьому пристрої.</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values-vi/strings.xml
+++ b/phone-app/src/main/res/values-vi/strings.xml
@@ -144,6 +144,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Đường dẫn endpoint Models</string>
+    <string name="custom_supports_vision">Mô hình hỗ trợ đầu vào hình ảnh (vision)</string>
+    <string name="custom_supports_vision_subtitle">Bật nếu mô hình này có thể phân tích hình ảnh (ví dụ: Gemma 4, LLaVA, MiniCPM-V). Cần thiết để phân tích ảnh trên endpoint tùy chỉnh.</string>
     <string name="secure_storage_unavailable">Không thể khởi tạo bộ nhớ mã hóa. Khóa API sẽ không được lưu trên thiết bị này.</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values-zh-rCN/strings.xml
+++ b/phone-app/src/main/res/values-zh-rCN/strings.xml
@@ -144,6 +144,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Models 端点路径</string>
+    <string name="custom_supports_vision">模型支持图像输入(视觉)</string>
+    <string name="custom_supports_vision_subtitle">如果此模型可以分析图像(例如 Gemma 4、LLaVA、MiniCPM-V)请开启。自定义端点的拍照分析需要此设置。</string>
     <string name="secure_storage_unavailable">无法初始化加密存储。API 密钥将不会保存在此设备上。</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values-zh-rTW/strings.xml
+++ b/phone-app/src/main/res/values-zh-rTW/strings.xml
@@ -144,6 +144,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Models 端點路徑</string>
+    <string name="custom_supports_vision">模型支援影像輸入(視覺)</string>
+    <string name="custom_supports_vision_subtitle">若此模型可分析圖片(例如 Gemma 4、LLaVA、MiniCPM-V)請開啟。自訂端點的拍照分析需要此設定。</string>
     <string name="secure_storage_unavailable">無法初始化加密儲存。API 金鑰將不會儲存在此裝置上。</string>
     
     <!-- API Key Validation -->

--- a/phone-app/src/main/res/values/strings.xml
+++ b/phone-app/src/main/res/values/strings.xml
@@ -150,6 +150,8 @@
     <string name="protocol_chat_completions">Chat Completions</string>
     <string name="protocol_responses">Responses</string>
     <string name="custom_models_path">Models endpoint path</string>
+    <string name="custom_supports_vision">Model supports image input (vision)</string>
+    <string name="custom_supports_vision_subtitle">Enable if this model can analyze images (e.g., Gemma 4, LLaVA, MiniCPM-V). Required for photo analysis on custom endpoints.</string>
 
     <!-- Secure storage -->
     <string name="secure_storage_unavailable">Encrypted storage could not be initialized. API keys will not be saved on this device.</string>

--- a/phone-app/src/test/java/com/example/rokidphone/ai/catalog/ModelCapabilityResolverTest.kt
+++ b/phone-app/src/test/java/com/example/rokidphone/ai/catalog/ModelCapabilityResolverTest.kt
@@ -1,0 +1,75 @@
+package com.example.rokidphone.ai.catalog
+
+import com.example.rokidphone.data.AiProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Manual capability override tests (Custom endpoints — issue #9).
+ */
+@RunWith(RobolectricTestRunner::class)
+class ModelCapabilityResolverTest {
+
+    @Test
+    fun `empty override keys yield null overrides`() {
+        assertThat(ModelCapabilityResolver.overridesFromKeys(AiProvider.CUSTOM, emptySet())).isNull()
+    }
+
+    @Test
+    fun `vision key enables image input on a text-only provider default`() {
+        val overrides = ModelCapabilityResolver.overridesFromKeys(
+            AiProvider.CUSTOM,
+            setOf(ModelCapabilityResolver.OVERRIDE_VISION)
+        )
+        assertThat(overrides).isNotNull()
+        assertThat(overrides!!.imageInput).isTrue()
+        // Provider default for CUSTOM is text-only, so this proves the override worked.
+        assertThat(ModelCapabilityResolver.providerDefault(AiProvider.CUSTOM).imageInput).isFalse()
+    }
+
+    @Test
+    fun `unknown override keys are ignored`() {
+        val overrides = ModelCapabilityResolver.overridesFromKeys(
+            AiProvider.CUSTOM,
+            setOf("teleportation")
+        )
+        assertThat(overrides).isNotNull()
+        assertThat(overrides!!.imageInput).isFalse()
+        assertThat(overrides.audioInput).isFalse()
+    }
+
+    @Test
+    fun `audio input key enables audio input`() {
+        val overrides = ModelCapabilityResolver.overridesFromKeys(
+            AiProvider.CUSTOM,
+            setOf(ModelCapabilityResolver.OVERRIDE_AUDIO_INPUT)
+        )
+        assertThat(overrides!!.audioInput).isTrue()
+    }
+
+    @Test
+    fun `manual override wins over fallback map for custom models`() {
+        // "minicpm-v-2.6" exists in the Custom fallback list with vision support.
+        // A manual override set that does NOT include vision must not add it back.
+        val overrides = ModelCapabilityResolver.overridesFromKeys(AiProvider.CUSTOM, emptySet())
+        val resolved = ModelCapabilityResolver.resolve(
+            AiProvider.CUSTOM,
+            "minicpm-v-2.6",
+            manualOverrides = overrides
+        )
+        // overrides is null here → fallback map applies (vision true)
+        assertThat(resolved.imageInput).isTrue()
+
+        // With an explicit override set, the user's declaration wins.
+        val withOverride = ModelCapabilityResolver.resolve(
+            AiProvider.CUSTOM,
+            "gemma-4-e4b",
+            manualOverrides = ModelCapabilityResolver.overridesFromKeys(
+                AiProvider.CUSTOM, setOf(ModelCapabilityResolver.OVERRIDE_VISION)
+            )
+        )
+        assertThat(withOverride.imageInput).isTrue()
+    }
+}

--- a/phone-app/src/test/java/com/example/rokidphone/service/ai/CustomEndpointVisionTest.kt
+++ b/phone-app/src/test/java/com/example/rokidphone/service/ai/CustomEndpointVisionTest.kt
@@ -1,0 +1,118 @@
+package com.example.rokidphone.service.ai
+
+import com.example.rokidphone.ai.catalog.ModelCapabilities
+import com.example.rokidphone.data.AiProvider
+import com.example.rokidphone.data.ApiSettings
+import com.example.rokidphone.testutil.MockWebServerRule
+import com.example.rokidphone.testutil.TestFixtures
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import okhttp3.Headers.Companion.headersOf
+import org.json.JSONObject
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Issue #9: Custom endpoint (LM Studio) with a vision-capable local model
+ * (e.g. Gemma 4 e4B) must be able to analyze photos when the user enables
+ * the manual vision override — and must stay blocked without it.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CustomEndpointVisionTest {
+
+    @get:Rule
+    val mockServer = MockWebServerRule()
+
+    private fun jsonResponse(body: String, code: Int = 200) = MockResponse(
+        code = code,
+        body = body,
+        headers = headersOf("Content-Type", "application/json")
+    )
+
+    private fun customService(overrides: ModelCapabilities? = null) = OpenAiCompatibleService(
+        apiKey = "",
+        baseUrl = mockServer.baseUrl,
+        modelId = "gemma-4-e4b",
+        providerType = AiProvider.CUSTOM,
+        capabilityOverrides = overrides
+    )
+
+    @Test
+    fun `analyzeImage - custom endpoint without override is rejected before any request`() = runTest {
+        val result = customService().analyzeImage(TestFixtures.createTestJpeg(), "describe")
+
+        assertThat(result).contains("does not support")
+        assertThat(mockServer.server.requestCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `analyzeImage - custom endpoint with vision override sends image request`() = runTest {
+        mockServer.server.enqueue(
+            jsonResponse(TestFixtures.MockResponses.openAiChatSuccess("a street scene"))
+        )
+
+        val service = customService(ModelCapabilities(imageInput = true, streaming = true))
+        val result = service.analyzeImage(TestFixtures.createTestJpeg(), "what is this?")
+
+        assertThat(result).isEqualTo("a street scene")
+        val request = mockServer.server.takeRequest()
+        assertThat(request.path).isEqualTo("/chat/completions")
+        val body = JSONObject(request.body.readUtf8())
+        assertThat(body.getString("model")).isEqualTo("gemma-4-e4b")
+        val content = body.getJSONArray("messages").getJSONObject(0).getJSONArray("content")
+        assertThat(content.getJSONObject(1).getString("type")).isEqualTo("image_url")
+        assertThat(
+            content.getJSONObject(1).getJSONObject("image_url").getString("url")
+        ).startsWith("data:image/jpeg;base64,")
+    }
+
+    @Test
+    fun `policy - custom with vision override uses image_url format, without uses NONE`() {
+        val withVision = ProviderRequestPolicies.resolve(
+            AiProvider.CUSTOM, "gemma-4-e4b", ModelCapabilities(imageInput = true)
+        )
+        assertThat(withVision.imageContentFormat).isEqualTo(ImageContentFormat.OPENAI_IMAGE_URL)
+
+        val without = ProviderRequestPolicies.resolve(
+            AiProvider.CUSTOM, "gemma-4-e4b", ModelCapabilities()
+        )
+        assertThat(without.imageContentFormat).isEqualTo(ImageContentFormat.NONE)
+    }
+
+    @Test
+    fun `factory - customCapabilityOverrides setting enables image analysis end to end`() = runTest {
+        val settings = ApiSettings(
+            aiProvider = AiProvider.CUSTOM,
+            customBaseUrl = mockServer.baseUrl,
+            customModelName = "gemma-4-e4b",
+            customCapabilityOverrides = setOf("vision")
+        )
+        mockServer.server.enqueue(
+            jsonResponse(TestFixtures.MockResponses.openAiChatSuccess("factory vision works"))
+        )
+
+        val service = AiServiceFactory.createService(settings)
+        val result = service.analyzeImage(TestFixtures.createTestJpeg(), "describe")
+
+        assertThat(result).isEqualTo("factory vision works")
+        assertThat(mockServer.server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `factory - default custom settings keep image analysis blocked`() = runTest {
+        val settings = ApiSettings(
+            aiProvider = AiProvider.CUSTOM,
+            customBaseUrl = mockServer.baseUrl,
+            customModelName = "gemma-4-e4b"
+        )
+
+        val service = AiServiceFactory.createService(settings)
+        val result = service.analyzeImage(TestFixtures.createTestJpeg(), "describe")
+
+        assertThat(result).contains("does not support")
+        assertThat(mockServer.server.requestCount).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #9 — Custom Endpoint (LM Studio) with vision-capable local models (e.g. Gemma 4 e4B) was blocked from photo analysis with "Image Analysis is not available on this model", even though the model supports vision.

**Root cause:** the image-analysis gate resolves capabilities via `ModelCapabilityResolver`, which for Custom endpoints falls back to a text-only provider default. LM Studio's `/models` does not report modality metadata, and the `manualOverrides` hook in the resolver was never wired to anything — no UI switch, no setting flow into service construction.

## Changes

- **Resolver** (`ModelCapabilityResolver.kt`): manual overrides now outrank the fallback capability map (the user knows their local model best); new `overridesFromKeys()` builds `ModelCapabilities` from the persisted `customCapabilityOverrides` keys (`vision`, `audio_input`).
- **Service** (`OpenAiCompatibleService.kt`): new `capabilityOverrides` constructor param; effective capabilities now drive both the request policy (`imageContentFormat` becomes `OPENAI_IMAGE_URL`) and the `analyzeImage()` gate.
- **Factory** (`AiServiceFactory.kt`): Custom service construction (chat + connection test) passes the setting through.
- **Settings UI** (`SettingsScreen.kt`): new **"Model supports image input (vision)"** switch in Custom Provider Settings; persisted in the existing `customCapabilityOverrides` field.
- **i18n**: switch title/subtitle added to all 13 locales.
- **Tests**: `ModelCapabilityResolverTest` (override key rules, priority), `CustomEndpointVisionTest` (gate blocked without override, image request sent with override, policy format, factory end-to-end with mocked LM Studio endpoint).

## Behavior

- Default stays **OFF** — non-custom providers and existing users see zero behavior change.
- With the switch ON, photo capture/analysis flows through the standard Chat Completions `image_url` format to the custom endpoint.

## Verification

- `:phone-app:testDebugUnitTest` — full suite passes (incl. 11 new tests)
- `:phone-app:assembleDebug` + `:phone-app:lintDebug` — pass

## Notes

Real-device verification with an actual LM Studio + Gemma 4 e4B instance is still recommended (tests use MockWebServer with an OpenAI-compatible endpoint).